### PR TITLE
boolean: allow arithmetic. integer: fix bitwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 Expr is a string expression parser in go. Not a fancy eval, just a simple and lightweight expr parser. Bool, Float64 and Int (with bitwise opperators) are available.
 
-```js
+```go
 "1 + 1" -> 2
-"1 < 2" -> true
-"true && false" -> false
+"1 < 2 + 2" -> true
+"true && !false" -> true
 ```
 
 ## Usage
@@ -18,10 +18,15 @@ Expr is a string expression parser in go. Not a fancy eval, just a simple and li
     - "1 < 2" -> true
     - "1 > 2" -> false
     - "true || false" -> true
-- However, arithmetic is not supported at the moment, **it WON'T DO "1 + 2 > 1" -> true [X]***
+    - "true && !false" -> true
+- Arithmetic operation are supported. e.g:
+    - "1 + 2 > 1" -> true
+    - "(1 * 10) > -2" -> true
 - Supported operators:
     - Comparison: [==, !=, <, <=, >, >=]
-    - Logical: [&&, ||]
+    - Logical: [&&, ||, !]
+    - Arithmetic: [+, -, *, /, %] *(the % operator is only work for interger operation)*
+
 ```go
     str := "((1 < 2 && 3 > 4) || 1 == 1) && 4 < 5"
     v, err := expr.Bool(str)
@@ -37,6 +42,7 @@ Expr is a string expression parser in go. Not a fancy eval, just a simple and li
     - "2.2 + 2" -> 4.2
 - Supported operators:
     - Arithmetic: [+, -, *, /]
+
 ```go
     str := "((2 * 2) * (8 + 2) * 2) + 2.56789"
     v, err := expr.Float64(str)
@@ -52,7 +58,11 @@ Expr is a string expression parser in go. Not a fancy eval, just a simple and li
     - "2.2 + 2" -> 4
 - Supported operators:
     - Arithmetic: [+, -, *, /, %]
-    - Bitwise: [&, |, ^, &^, <<, >>]
+    - Bitwise: [&, |, ^, &^, <<, >>] (signed integer)
+- Notes: 
+    - << and >> operators are not permitted to be used in signed integer for go version less than 1.13.x.
+    - Reference: [https://golang.org/doc/go1.13#language](https://golang.org/doc/go1.13#language)
+
 ```go
     str := "((2 * 2) * (8 + 2) * 2) + 2.56789"
     v, err := expr.Int(str)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -62,7 +62,7 @@ func BenchmarkFloat64(b *testing.B) {
 }
 
 func BenchmarkBoolean(b *testing.B) {
-	booleanExpr := "(\"expr\" == \"expr\" && \"Expr\" == \"expr\") || true == true && 1 < 2 && (1 > 2 || 1 == 1)"
+	booleanExpr := "(\"expr\" == \"expr\" && \"Expr\" == \"expr\") || !false && 1 < 2 && (1 > 2 || -1 > -2)"
 	multiply := func(s string, n int) string {
 		for i := 1; i < n; i++ {
 			s += " && (" + s + ")"

--- a/boolean/boolean.go
+++ b/boolean/boolean.go
@@ -2,13 +2,18 @@ package boolean
 
 import (
 	"errors"
+	"fmt"
 	"go/ast"
 	"go/token"
 	"strconv"
+	"strings"
 )
 
 // ErrUnsupportedOperator is error unsupported operator
 var ErrUnsupportedOperator = errors.New("unsupported operator")
+
+// ErrInvalidOperationOnFloat is error invalid operation on float
+var ErrInvalidOperationOnFloat = errors.New("invalid operation on float")
 
 // Visitor is boolean visitor interface
 type Visitor interface {
@@ -22,8 +27,98 @@ func NewVisitor() Visitor {
 }
 
 type visitor struct {
-	res string
-	err error
+	kind token.Token
+	res  string
+	err  error
+}
+
+func parseUnaryExpr(unaryExpr *ast.UnaryExpr) (string, token.Token, error) {
+	switch unaryExpr.Op {
+	case token.NOT:
+		v := &visitor{}
+		ast.Walk(v, unaryExpr.X)
+		if v.err != nil {
+			return "", v.kind, v.err
+		}
+		res, _ := strconv.ParseBool(v.res)
+		return strconv.FormatBool(!res), 0, nil
+	case token.ADD:
+		v := &visitor{}
+		ast.Walk(v, unaryExpr.X)
+		if v.err != nil {
+			return "", v.kind, v.err
+		}
+		return v.res, v.kind, nil
+	case token.SUB:
+		v := &visitor{}
+		ast.Walk(v, unaryExpr.X)
+		if v.err != nil {
+			return "", v.kind, v.err
+		}
+
+		if strings.HasPrefix(v.res, "-") {
+			if v.kind == token.FLOAT {
+				value, _ := strconv.ParseFloat(v.res, 64)
+				return fmt.Sprintf("%f", value*-1), v.kind, nil
+			}
+			value, _ := strconv.Atoi(v.res)
+			return fmt.Sprintf("%d", value*-1), v.kind, nil
+		}
+
+		return "-" + v.res, v.kind, nil
+	default:
+		return "", 0, ErrUnsupportedOperator
+	}
+}
+
+func tryArithmetic(xVisitor, yVisitor *visitor, op token.Token) (string, token.Token, error) {
+	switch op {
+	case token.ADD:
+		if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+			x, _ := strconv.ParseFloat(xVisitor.res, 64)
+			y, _ := strconv.ParseFloat(yVisitor.res, 64)
+			return fmt.Sprintf("%f", x+y), token.FLOAT, nil
+		}
+		x, _ := strconv.Atoi(xVisitor.res)
+		y, _ := strconv.Atoi(yVisitor.res)
+		return fmt.Sprintf("%d", x+y), token.INT, nil
+	case token.SUB:
+		if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+			x, _ := strconv.ParseFloat(xVisitor.res, 64)
+			y, _ := strconv.ParseFloat(yVisitor.res, 64)
+			return fmt.Sprintf("%f", x-y), token.FLOAT, nil
+		}
+		x, _ := strconv.Atoi(xVisitor.res)
+		y, _ := strconv.Atoi(yVisitor.res)
+		return fmt.Sprintf("%d", x-y), token.INT, nil
+	case token.MUL:
+		if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+			x, _ := strconv.ParseFloat(xVisitor.res, 64)
+			y, _ := strconv.ParseFloat(yVisitor.res, 64)
+			return fmt.Sprintf("%f", x*y), token.FLOAT, nil
+		}
+		x, _ := strconv.Atoi(xVisitor.res)
+		y, _ := strconv.Atoi(yVisitor.res)
+		return fmt.Sprintf("%d", x*y), token.INT, nil
+	case token.QUO:
+		if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+			x, _ := strconv.ParseFloat(xVisitor.res, 64)
+			y, _ := strconv.ParseFloat(yVisitor.res, 64)
+			return fmt.Sprintf("%f", x/y), token.FLOAT, nil
+		}
+		x, _ := strconv.Atoi(xVisitor.res)
+		y, _ := strconv.Atoi(yVisitor.res)
+		return fmt.Sprintf("%d", x/y), token.INT, nil
+	case token.REM:
+		if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+			return "", 0, fmt.Errorf("operator %s is not supported on untyped float: %w", "%", ErrInvalidOperationOnFloat)
+		}
+		x, _ := strconv.Atoi(xVisitor.res)
+		y, _ := strconv.Atoi(yVisitor.res)
+		return fmt.Sprintf("%d", x/y), token.INT, nil
+	default:
+		return "", 0, ErrUnsupportedOperator
+	}
 }
 
 func (v *visitor) Visit(node ast.Node) ast.Visitor {
@@ -34,14 +129,10 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 	switch d := node.(type) {
 	case *ast.ParenExpr:
 		return v.Visit(d.X)
+	case *ast.UnaryExpr:
+		v.res, v.kind, v.err = parseUnaryExpr(d)
+		return nil
 	case *ast.BinaryExpr:
-		switch d.Op { // early validate operator
-		case token.EQL, token.NEQ, token.GTR, token.GEQ, token.LSS, token.LEQ, token.LAND, token.LOR:
-		default:
-			v.err = ErrUnsupportedOperator
-			return nil
-		}
-
 		xVisitor := &visitor{}
 		ast.Walk(xVisitor, d.X)
 		if xVisitor.err != nil {
@@ -64,31 +155,100 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 		case token.NEQ:
 			v.res = strconv.FormatBool(x != y)
 		case token.GTR:
+			if xVisitor.kind != token.STRING && yVisitor.kind != token.STRING {
+				if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+					x, _ := strconv.ParseFloat(xVisitor.res, 64)
+					y, _ := strconv.ParseFloat(yVisitor.res, 64)
+
+					v.res = strconv.FormatBool(x > y)
+					return nil
+				}
+				x, _ := strconv.Atoi(xVisitor.res)
+				y, _ := strconv.Atoi(yVisitor.res)
+				v.res = strconv.FormatBool(x > y)
+				return nil
+			}
 			v.res = strconv.FormatBool(x > y)
 		case token.GEQ:
+			if xVisitor.kind != token.STRING && yVisitor.kind != token.STRING {
+				if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+					x, _ := strconv.ParseFloat(xVisitor.res, 64)
+					y, _ := strconv.ParseFloat(yVisitor.res, 64)
+
+					v.res = strconv.FormatBool(x >= y)
+					return nil
+				}
+				x, _ := strconv.Atoi(xVisitor.res)
+				y, _ := strconv.Atoi(yVisitor.res)
+				v.res = strconv.FormatBool(x >= y)
+				return nil
+			}
 			v.res = strconv.FormatBool(x >= y)
 		case token.LSS:
+			if xVisitor.kind != token.STRING && yVisitor.kind != token.STRING {
+				if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+					x, _ := strconv.ParseFloat(xVisitor.res, 64)
+					y, _ := strconv.ParseFloat(yVisitor.res, 64)
+
+					v.res = strconv.FormatBool(x < y)
+					return nil
+				}
+				x, _ := strconv.Atoi(xVisitor.res)
+				y, _ := strconv.Atoi(yVisitor.res)
+				v.res = strconv.FormatBool(x < y)
+				return nil
+			}
 			v.res = strconv.FormatBool(x < y)
 		case token.LEQ:
+			if xVisitor.kind != token.STRING && yVisitor.kind != token.STRING {
+				if xVisitor.kind == token.FLOAT || yVisitor.kind == token.FLOAT {
+					x, _ := strconv.ParseFloat(xVisitor.res, 64)
+					y, _ := strconv.ParseFloat(yVisitor.res, 64)
+
+					v.res = strconv.FormatBool(x <= y)
+					return nil
+				}
+				x, _ := strconv.Atoi(xVisitor.res)
+				y, _ := strconv.Atoi(yVisitor.res)
+				v.res = strconv.FormatBool(x <= y)
+				return nil
+			}
 			v.res = strconv.FormatBool(x <= y)
 		case token.LAND:
-			xbool, _ := strconv.ParseBool(x)
-			ybool, _ := strconv.ParseBool(y)
+			xbool, err := strconv.ParseBool(x)
+			if err != nil {
+				v.err = err
+				return nil
+			}
+			ybool, err := strconv.ParseBool(y)
+			if err != nil {
+				v.err = err
+				return nil
+			}
 			v.res = strconv.FormatBool(xbool && ybool)
 		case token.LOR:
-			xbool, _ := strconv.ParseBool(x)
-			ybool, _ := strconv.ParseBool(y)
+			xbool, err := strconv.ParseBool(x)
+			if err != nil {
+				v.err = err
+				return nil
+			}
+			ybool, err := strconv.ParseBool(y)
+			if err != nil {
+				v.err = err
+				return nil
+			}
 			v.res = strconv.FormatBool(xbool || ybool)
 		default:
-			v.err = ErrUnsupportedOperator
+			v.res, v.kind, v.err = tryArithmetic(xVisitor, yVisitor, d.Op)
 		}
-
 		return nil
 	case *ast.BasicLit:
 		v.res = d.Value
+		v.kind = d.Kind
 		return nil
 	case *ast.Ident:
 		v.res = d.String()
+		v.kind = token.STRING
 		return nil
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -86,6 +86,10 @@ func ExampleBool() {
 		"1 + 2 > 1 * 2",
 		"1 + 2 < (2 + 2) * 10",
 		"1 < 1 <",
+		"-1 > -10",
+		"true",
+		"!false",
+		"!false || false",
 	}
 
 	for _, value := range values {
@@ -100,7 +104,11 @@ func ExampleBool() {
 	// true <nil>
 	// true <nil>
 	// false <nil>
-	// false unsupported operator
-	// false unsupported operator
+	// true <nil>
+	// true <nil>
 	// false 1:8: expected operand, found 'EOF'
+	// true <nil>
+	// true <nil>
+	// true <nil>
+	// true <nil>
 }

--- a/expr.go
+++ b/expr.go
@@ -9,13 +9,14 @@ import (
 	"github.com/muktihari/expr/integer"
 )
 
-// Int parses the given expr string into int as a result. e.g: "2 + 2" -> 4, "2.2 + 2" -> 4.
+// Int parses the given expr string into int as a result.
+// - e.g:
+// 	-"2 + 2" -> 4
+// 	-"2.2 + 2" -> 4
 //
-// Supported operators:
-//
-// Arithmetic: [+, -, *, /, %]
-//
-// Bitwise: [&, |, ^, &^, <<, >>]
+// - Supported operators:
+// 	- Arithmetic: [+, -, *, /, %]
+// 	- Bitwise: [&, |, ^, &^, <<, >>]
 func Int(str string) (int, error) {
 	expr, err := parser.ParseExpr(str)
 	if err != nil {
@@ -27,11 +28,13 @@ func Int(str string) (int, error) {
 	return visitor.Result()
 }
 
-// Float64 parses the given expr string into float64 as a result . e.g: "2 + 2" -> 4, "2.2 + 2" -> 4.2
+// Float64 parses the given expr string into float64 as a result.
+// - e.g:
+// 	- "2 + 2" -> 4
+// 	- "2.2 + 2" -> 4.2
 //
-// Supported operators:
-//
-// Arithmetic: [+, -, *, /]
+// - Supported operators:
+// 	- Arithmetic: [+, -, *, /]
 func Float64(str string) (float64, error) {
 	expr, err := parser.ParseExpr(str)
 	if err != nil {
@@ -43,15 +46,19 @@ func Float64(str string) (float64, error) {
 	return visitor.Result()
 }
 
-// Bool parses the given expr string into boolean as a result. e.g: "1 < 2" -> true, "1 > 2" -> false, "true || false" -> true.
+// Bool parses the given expr string into boolean as a result.
+// - e.g:
+// 	- "1 < 2" -> true
+// 	- "1 > 2" -> false
+// 	- "true || false" -> true
 //
-// However, arithmetic is not supported at the moment, it WON'T DO "1 + 2 > 1" -> true [X]
-//
-// Supported operators:
-//
-// Comparison: [==, !=, <, <=, >, >=]
-//
-// Logical: [&&, ||]
+// - Arithmetic operation are supported. e.g:
+// 	- "1 + 2 > 1" -> true
+//	- "(1 * 10) > -2" -> true
+// - Supported operators:
+// 	- Comparison: [==, !=, <, <=, >, >=]
+// 	- Logical: [&&, ||, !]
+// 	- Arithmetic: [+, -, *, /, %] (the % operator is only work for interger operation)
 func Bool(str string) (bool, error) {
 	expr, err := parser.ParseExpr(str)
 	if err != nil {

--- a/expr_test.go
+++ b/expr_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/muktihari/expr"
-	"github.com/muktihari/expr/boolean"
 	"github.com/muktihari/expr/float"
 	"github.com/muktihari/expr/integer"
 )
@@ -100,7 +99,7 @@ func TestBool(t *testing.T) {
 	}{
 		{In: "1 < 2", Eq: true},
 		{In: "2 < 1", Eq: false},
-		{In: "2 < 1 && (1 + 1) > 1", Eq: false, Err: boolean.ErrUnsupportedOperator},
+		{In: "2 < 1 && (1 + 1) > 1", Eq: false},
 		{In: "(1 < 2 && 3 > 4) || 1 == 1", Eq: true},
 		{In: "((1 < 2 && 3 > 4) || 1 == 1) && 4 > 5", Eq: false},
 		{In: "false && false", Eq: false},
@@ -114,6 +113,13 @@ func TestBool(t *testing.T) {
 		{In: "(\"expr\" == \"expr\" && \"Expr\" == \"expr\") || 1 == 1 ", Eq: true},
 		{In: "(\"expr\" == \"expr\" && \"Expr\" == \"expr\") || true == true ", Eq: true},
 		{In: "(\"expr\" == \"expr\" && \"Expr\" == \"expr\") || true == false ", Eq: false},
+		{In: "true", Eq: true},
+		{In: "!false", Eq: true},
+		{In: "!false || false", Eq: true},
+		{In: "(-10 < -2) && -1 > -2", Eq: true},
+		{In: "-(-1) > -1", Eq: true},
+		{In: "-(-1.5) > +1.3", Eq: true},
+		{In: "-4 * -2 > -1", Eq: true},
 	}
 
 	for _, tc := range tt {

--- a/float/float.go
+++ b/float/float.go
@@ -35,41 +35,39 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 	case *ast.ParenExpr:
 		return v.Visit(d.X)
 	case *ast.BinaryExpr:
-		switch d.Op { // early validate operator
+		switch d.Op {
 		case token.ADD, token.SUB, token.MUL, token.QUO:
+			xVisitor := &visitor{}
+			ast.Walk(xVisitor, d.X)
+			if xVisitor.err != nil {
+				v.err = xVisitor.err
+				return nil
+			}
+			x := xVisitor.res
+
+			yVisitor := &visitor{}
+			ast.Walk(yVisitor, d.Y)
+			if yVisitor.err != nil {
+				v.err = yVisitor.err
+				return nil
+			}
+			y := yVisitor.res
+
+			switch d.Op {
+			case token.ADD:
+				v.res = x + y
+			case token.SUB:
+				v.res = x - y
+			case token.MUL:
+				v.res = x * y
+			case token.QUO:
+				v.res = x / y
+			}
+			return nil
 		default:
 			v.err = ErrUnsupportedOperator
 			return nil
 		}
-
-		xVisitor := &visitor{}
-		ast.Walk(xVisitor, d.X)
-		if xVisitor.err != nil {
-			v.err = xVisitor.err
-			return nil
-		}
-		x := xVisitor.res
-
-		yVisitor := &visitor{}
-		ast.Walk(yVisitor, d.Y)
-		if yVisitor.err != nil {
-			v.err = yVisitor.err
-			return nil
-		}
-		y := yVisitor.res
-
-		switch d.Op {
-		case token.ADD:
-			v.res = x + y
-		case token.SUB:
-			v.res = x - y
-		case token.MUL:
-			v.res = x * y
-		case token.QUO:
-			v.res = x / y
-		}
-
-		return nil
 	case *ast.BasicLit:
 		switch d.Kind {
 		case token.INT:

--- a/integer/integer.go
+++ b/integer/integer.go
@@ -22,8 +22,9 @@ func NewVisitor() Visitor {
 }
 
 type visitor struct {
-	res int
-	err error
+	res  int
+	base int // base10 except stated otherwise
+	err  error
 }
 
 func (v *visitor) Visit(node ast.Node) ast.Visitor {
@@ -35,59 +36,81 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 	case *ast.ParenExpr:
 		return v.Visit(d.X)
 	case *ast.BinaryExpr:
-		switch d.Op { // early validate operator
-		case token.ADD, token.SUB, token.MUL, token.QUO, token.REM, // arithmatic operators
-			token.AND, token.OR, token.XOR, token.AND_NOT, token.SHL, token.SHR: // bitwise operators
+		switch d.Op {
+		case token.ADD, token.SUB, token.MUL, token.QUO, token.REM: // arithmatic operators
+			xVisitor := &visitor{}
+			ast.Walk(xVisitor, d.X)
+			if xVisitor.err != nil {
+				v.err = xVisitor.err
+				return nil
+			}
+			x := xVisitor.res
+
+			yVisitor := &visitor{}
+			ast.Walk(yVisitor, d.Y)
+			if yVisitor.err != nil {
+				v.err = yVisitor.err
+				return nil
+			}
+			y := yVisitor.res
+
+			switch d.Op {
+			case token.ADD:
+				v.res = x + y
+			case token.SUB:
+				v.res = x - y
+			case token.MUL:
+				v.res = x * y
+			case token.QUO:
+				v.res = x / y
+			case token.REM:
+				v.res = x % y
+			}
+			return nil
+		case token.AND, token.OR, token.XOR, token.AND_NOT, token.SHL, token.SHR: // bitwise operators
+			xVisitor := &visitor{base: 2}
+			ast.Walk(xVisitor, d.X)
+			if xVisitor.err != nil {
+				v.err = xVisitor.err
+				return nil
+			}
+			x := xVisitor.res
+
+			yVisitor := &visitor{base: 2}
+			ast.Walk(yVisitor, d.Y)
+			if yVisitor.err != nil {
+				v.err = yVisitor.err
+				return nil
+			}
+			y := yVisitor.res
+			switch d.Op {
+			case token.AND:
+				v.res = x & y
+			case token.OR:
+				v.res = x | y
+			case token.XOR:
+				v.res = x ^ y
+			case token.AND_NOT:
+				v.res = x &^ y
+			case token.SHL:
+				v.res = x << y
+			case token.SHR:
+				v.res = x >> y
+			}
+			return nil
 		default:
 			v.err = ErrUnsupportedOperator
 			return nil
 		}
-
-		xVisitor := &visitor{}
-		ast.Walk(xVisitor, d.X)
-		if xVisitor.err != nil {
-			v.err = xVisitor.err
-			return nil
-		}
-		x := xVisitor.res
-
-		yVisitor := &visitor{}
-		ast.Walk(yVisitor, d.Y)
-		if yVisitor.err != nil {
-			v.err = yVisitor.err
-			return nil
-		}
-		y := yVisitor.res
-
-		switch d.Op {
-		case token.ADD:
-			v.res = x + y
-		case token.SUB:
-			v.res = x - y
-		case token.MUL:
-			v.res = x * y
-		case token.QUO:
-			v.res = x / y
-		case token.REM:
-			v.res = x % y
-		case token.AND:
-			v.res = x & y
-		case token.OR:
-			v.res = x | y
-		case token.XOR:
-			v.res = x ^ y
-		case token.AND_NOT:
-			v.res = x &^ y
-		case token.SHL:
-			v.res = x << y
-		case token.SHR:
-			v.res = x >> y
-		}
-
-		return nil
 	case *ast.BasicLit:
 		switch d.Kind {
 		case token.INT:
+			if v.base == 2 {
+				var res int64
+				res, v.err = strconv.ParseInt(d.Value, 2, 64)
+				v.res = int(res)
+				return nil
+			}
 			v.res, _ = strconv.Atoi(d.Value)
 		case token.FLOAT:
 			floatValue, _ := strconv.ParseFloat(d.Value, 32)


### PR DESCRIPTION
boolean:
- arithmetic operation are now supported and calculated before comparing the values
- float will be parse to float64 and int will be parse to int with at least 32 bits of size
- operation between float and int will be treat as float64.

integer:
- fix bitwise operation, now use base2 instead of base10
- the base2 parsing operation will use int64

additional:
- documentation is updated.
- new test cases are added