### PR TITLE
boolean/arithmetic: fix remainder/modulus operator

### DIFF
--- a/boolean/boolean.go
+++ b/boolean/boolean.go
@@ -115,7 +115,7 @@ func tryArithmetic(xVisitor, yVisitor *visitor, op token.Token) (string, token.T
 		}
 		x, _ := strconv.Atoi(xVisitor.res)
 		y, _ := strconv.Atoi(yVisitor.res)
-		return fmt.Sprintf("%d", x/y), token.INT, nil
+		return fmt.Sprintf("%d", x%y), token.INT, nil
 	default:
 		return "", 0, ErrUnsupportedOperator
 	}

--- a/expr_test.go
+++ b/expr_test.go
@@ -120,6 +120,8 @@ func TestBool(t *testing.T) {
 		{In: "-(-1) > -1", Eq: true},
 		{In: "-(-1.5) > +1.3", Eq: true},
 		{In: "-4 * -2 > -1", Eq: true},
+		{In: "10 % 2 > -2", Eq: true},
+		{In: "10 % 2 < 1", Eq: true},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
mistype modulus operator, should be %, was /. test case added.