### PR TITLE
perf: change underlying value from string to interface{}

### DIFF
--- a/bitwise.go
+++ b/bitwise.go
@@ -1,9 +1,9 @@
 package expr
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
-	"strconv"
 
 	"github.com/muktihari/expr/conv"
 )
@@ -25,32 +25,33 @@ func bitwise(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
 
 	if vy.kind != KindInt {
 		v.err = newBitwiseNonIntegerError(vy, binaryExpr.Y)
+		return
 	}
 
-	x, _ := strconv.ParseInt(vx.value, 0, 64)
-	y, _ := strconv.ParseInt(vy.value, 0, 64)
+	x := vx.value.(int64)
+	y := vy.value.(int64)
 
 	v.kind = KindInt
 	switch binaryExpr.Op {
 	case token.AND:
-		v.value = strconv.FormatInt(x&y, 10)
+		v.value = x & y
 	case token.OR:
-		v.value = strconv.FormatInt(x|y, 10)
+		v.value = x | y
 	case token.XOR:
-		v.value = strconv.FormatInt(x^y, 10)
+		v.value = x ^ y
 	case token.AND_NOT:
-		v.value = strconv.FormatInt(x&^y, 10)
+		v.value = x &^ y
 	case token.SHL:
-		v.value = strconv.FormatInt(x<<y, 10)
+		v.value = x << y
 	case token.SHR:
-		v.value = strconv.FormatInt(x>>y, 10)
+		v.value = x >> y
 	}
 }
 
 func newBitwiseNonIntegerError(v *Visitor, e ast.Expr) error {
 	s := conv.FormatExpr(e)
 	return &SyntaxError{
-		Msg: "result value of \"" + s + "\" is \"" + v.value + "\" which is not an integer",
+		Msg: "result value of \"" + s + "\" is \"" + fmt.Sprintf("%v", v.value) + "\" which is not an integer",
 		Pos: int(e.Pos()),
 		Err: ErrBitwiseOperation,
 	}

--- a/comparison.go
+++ b/comparison.go
@@ -1,21 +1,35 @@
 package expr
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
-	"strconv"
+
+	"github.com/muktihari/expr/conv"
 )
 
 func comparison(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
 	v.kind = KindBoolean
-	if vx.kind == KindBoolean || vy.kind == KindBoolean {
-		compareBoolean(v, vx, vy, binaryExpr)
+	if vx.kind == KindBoolean && vy.kind == KindBoolean {
+		compareMustBoolean(v, vx, vy, binaryExpr)
 		return
 	}
-	if vx.kind == KindString || vy.kind == KindString {
-		compareString(v, vx, vy, binaryExpr)
+	if vx.kind == KindString && vy.kind == KindString {
+		compareMustString(v, vx, vy, binaryExpr)
 		return
 	}
+
+	// numeric can be compare one another e.g. 0.4 < 1 -> true
+	// numeric guards:
+	if vx.kind <= numeric_beg || vx.kind >= numeric_end {
+		v.err = newComparisonNonNumericError(vx, binaryExpr.X)
+		return
+	}
+	if vy.kind <= numeric_beg || vy.kind >= numeric_end {
+		v.err = newComparisonNonNumericError(vy, binaryExpr.Y)
+		return
+	}
+
 	if vx.kind == KindImag || vy.kind == KindImag {
 		compareComplex(v, vx, vy, binaryExpr)
 		return
@@ -24,16 +38,30 @@ func comparison(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
 		compareFloat(v, vx, vy, binaryExpr)
 		return
 	}
-
-	compareInt(v, vx, vy, binaryExpr)
+	if vx.kind == KindInt || vy.kind == KindInt {
+		compareInt(v, vx, vy, binaryExpr)
+		return
+	}
 }
 
-func compareBoolean(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
+func newComparisonNonNumericError(v *Visitor, e ast.Expr) error {
+	s := conv.FormatExpr(e)
+	return &SyntaxError{
+		Msg: "result of \"" + s + "\" is \"" + fmt.Sprintf("%v", v.value) + "\" which is not a number",
+		Pos: v.pos,
+		Err: ErrComparisonOperation,
+	}
+}
+
+func compareMustBoolean(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
+	x := vx.value.(bool)
+	y := vy.value.(bool)
+
 	switch binaryExpr.Op {
 	case token.EQL:
-		v.value = strconv.FormatBool(vx.value == vy.value)
+		v.value = x == y
 	case token.NEQ:
-		v.value = strconv.FormatBool(vx.value != vy.value)
+		v.value = x != y
 	default:
 		v.kind = KindIllegal
 		v.err = &SyntaxError{
@@ -45,20 +73,23 @@ func compareBoolean(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
 	}
 }
 
-func compareString(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
+func compareMustString(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
+	x := vx.value.(string)
+	y := vy.value.(string)
+
 	switch binaryExpr.Op {
 	case token.EQL:
-		v.value = strconv.FormatBool(vx.value == vy.value)
+		v.value = x == y
 	case token.NEQ:
-		v.value = strconv.FormatBool(vx.value != vy.value)
+		v.value = x != y
 	case token.GTR:
-		v.value = strconv.FormatBool(vx.value > vy.value)
+		v.value = x > y
 	case token.GEQ:
-		v.value = strconv.FormatBool(vx.value >= vy.value)
+		v.value = x >= y
 	case token.LSS:
-		v.value = strconv.FormatBool(vx.value < vy.value)
+		v.value = x < y
 	case token.LEQ:
-		v.value = strconv.FormatBool(vx.value <= vy.value)
+		v.value = x <= y
 	}
 }
 
@@ -69,9 +100,9 @@ func compareComplex(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
 
 	switch binaryExpr.Op {
 	case token.EQL:
-		v.value = strconv.FormatBool(x == y)
+		v.value = x == y
 	case token.NEQ:
-		v.value = strconv.FormatBool(x != y)
+		v.value = x != y
 	default:
 		v.kind = KindIllegal
 		v.err = &SyntaxError{
@@ -89,36 +120,36 @@ func compareFloat(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
 
 	switch binaryExpr.Op {
 	case token.EQL:
-		v.value = strconv.FormatBool(x == y)
+		v.value = x == y
 	case token.NEQ:
-		v.value = strconv.FormatBool(x != y)
+		v.value = x != y
 	case token.GTR:
-		v.value = strconv.FormatBool(x > y)
+		v.value = x > y
 	case token.GEQ:
-		v.value = strconv.FormatBool(x >= y)
+		v.value = x >= y
 	case token.LSS:
-		v.value = strconv.FormatBool(x < y)
+		v.value = x < y
 	case token.LEQ:
-		v.value = strconv.FormatBool(x <= y)
+		v.value = x <= y
 	}
 }
 
 func compareInt(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
-	x, _ := strconv.ParseInt(vx.value, 0, 64)
-	y, _ := strconv.ParseInt(vy.value, 0, 64)
+	x := vx.value.(int64)
+	y := vy.value.(int64)
 
 	switch binaryExpr.Op {
 	case token.EQL:
-		v.value = strconv.FormatBool(x == y)
+		v.value = x == y
 	case token.NEQ:
-		v.value = strconv.FormatBool(x != y)
+		v.value = x != y
 	case token.GTR:
-		v.value = strconv.FormatBool(x > y)
+		v.value = x > y
 	case token.GEQ:
-		v.value = strconv.FormatBool(x >= y)
+		v.value = x >= y
 	case token.LSS:
-		v.value = strconv.FormatBool(x < y)
+		v.value = x < y
 	case token.LEQ:
-		v.value = strconv.FormatBool(x <= y)
+		v.value = x <= y
 	}
 }

--- a/comparison.go
+++ b/comparison.go
@@ -135,8 +135,8 @@ func compareFloat(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
 }
 
 func compareInt(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
-	x := vx.value.(int64)
-	y := vy.value.(int64)
+	x := parseInt(vx.value, vx.kind)
+	y := parseInt(vy.value, vy.kind)
 
 	switch binaryExpr.Op {
 	case token.EQL:

--- a/comparison_test.go
+++ b/comparison_test.go
@@ -12,24 +12,24 @@ func TestComparison(t *testing.T) {
 	tt := []struct {
 		v, vx, vy      *Visitor
 		ops            []token.Token
-		expectedValues []string
+		expectedValues []interface{}
 		expectedErrs   []error
 	}{
 		// compareBoolean
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "true", kind: KindBoolean},
+			vx:             &Visitor{value: true, kind: KindBoolean},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: "false", kind: KindBoolean},
-			expectedValues: []string{"false", "true"},
+			vy:             &Visitor{value: false, kind: KindBoolean},
+			expectedValues: []interface{}{false, true},
 			expectedErrs:   []error{nil, nil},
 		},
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "true", kind: KindBoolean},
+			vx:             &Visitor{value: true, kind: KindBoolean},
 			ops:            []token.Token{token.GTR},
-			vy:             &Visitor{value: "false", kind: KindBoolean},
-			expectedValues: []string{""},
+			vy:             &Visitor{value: false, kind: KindBoolean},
+			expectedValues: []interface{}{nil},
 			expectedErrs:   []error{ErrUnsupportedOperator},
 		},
 		// compareString
@@ -38,43 +38,79 @@ func TestComparison(t *testing.T) {
 			vx:             &Visitor{value: "\"abc\"", kind: KindString},
 			ops:            []token.Token{token.EQL, token.NEQ, token.GTR, token.GEQ, token.LSS, token.LEQ},
 			vy:             &Visitor{value: "\"abc\"", kind: KindString},
-			expectedValues: []string{"true", "false", "false", "true", "false", "true"},
+			expectedValues: []interface{}{true, false, false, true, false, true},
 			expectedErrs:   []error{nil, nil, nil, nil, nil, nil},
 		},
 		// compareImag
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "(2+0i)", kind: KindImag},
+			vx:             &Visitor{value: (2 + 0i), kind: KindImag},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: "(2+0i)", kind: KindImag},
-			expectedValues: []string{"true", "false"},
+			vy:             &Visitor{value: (2 + 0i), kind: KindImag},
+			expectedValues: []interface{}{true, false},
 			expectedErrs:   []error{nil, nil},
 		},
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "(2+0i)", kind: KindImag},
+			vx:             &Visitor{value: (2 + 0i), kind: KindImag},
 			ops:            []token.Token{token.GTR},
-			vy:             &Visitor{value: "(2+0i)", kind: KindImag},
-			expectedValues: []string{""},
+			vy:             &Visitor{value: (2 + 0i), kind: KindImag},
+			expectedValues: []interface{}{nil},
 			expectedErrs:   []error{ErrUnsupportedOperator},
 		},
 		// compareFloat
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "2.0", kind: KindFloat},
+			vx:             &Visitor{value: float64(2.0), kind: KindFloat},
 			ops:            []token.Token{token.EQL, token.NEQ, token.GTR, token.GEQ, token.LSS, token.LEQ},
-			vy:             &Visitor{value: "2", kind: KindInt},
-			expectedValues: []string{"true", "false", "false", "true", "false", "true"},
+			vy:             &Visitor{value: int64(2), kind: KindInt},
+			expectedValues: []interface{}{true, false, false, true, false, true},
 			expectedErrs:   []error{nil, nil, nil, nil, nil, nil},
 		},
 		// compareInt
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "2", kind: KindInt},
+			vx:             &Visitor{value: int64(2), kind: KindInt},
 			ops:            []token.Token{token.EQL, token.NEQ, token.GTR, token.GEQ, token.LSS, token.LEQ},
-			vy:             &Visitor{value: "2", kind: KindInt},
-			expectedValues: []string{"true", "false", "false", "true", "false", "true"},
+			vy:             &Visitor{value: int64(2), kind: KindInt},
+			expectedValues: []interface{}{true, false, false, true, false, true},
 			expectedErrs:   []error{nil, nil, nil, nil, nil, nil},
+		},
+		// compare boolean to int
+		{
+			v:              &Visitor{},
+			vx:             &Visitor{value: true, kind: KindBoolean},
+			ops:            []token.Token{token.EQL, token.NEQ},
+			vy:             &Visitor{value: int64(10), kind: KindInt},
+			expectedValues: []interface{}{nil, nil},
+			expectedErrs:   []error{ErrComparisonOperation, ErrComparisonOperation},
+		},
+		// compareInt to boolean
+		{
+			v:              &Visitor{},
+			vx:             &Visitor{value: int64(10), kind: KindInt},
+			ops:            []token.Token{token.EQL, token.NEQ},
+			vy:             &Visitor{value: true, kind: KindBoolean},
+			expectedValues: []interface{}{nil, nil},
+			expectedErrs:   []error{ErrComparisonOperation, ErrComparisonOperation},
+		},
+		// compare boolean to string
+		{
+			v:              &Visitor{},
+			vx:             &Visitor{value: true, kind: KindBoolean},
+			ops:            []token.Token{token.EQL, token.NEQ},
+			vy:             &Visitor{value: "true", kind: KindString},
+			expectedValues: []interface{}{nil, nil},
+			expectedErrs:   []error{ErrComparisonOperation, ErrComparisonOperation},
+		},
+		// compare string to boolean
+		{
+			v:              &Visitor{},
+			vx:             &Visitor{value: "true", kind: KindString},
+			ops:            []token.Token{token.EQL, token.NEQ},
+			vy:             &Visitor{value: true, kind: KindBoolean},
+			expectedValues: []interface{}{nil, nil},
+			expectedErrs:   []error{ErrComparisonOperation, ErrComparisonOperation},
 		},
 	}
 
@@ -87,11 +123,11 @@ func TestComparison(t *testing.T) {
 				expectedErr   = tc.expectedErrs[i]
 				expectedValue = tc.expectedValues[i]
 				be            = &ast.BinaryExpr{
-					X:  &ast.BasicLit{Value: tc.vx.value},
+					X:  &ast.BasicLit{Value: fmt.Sprintf("%v", tc.vx.value)},
 					Op: op,
-					Y:  &ast.BasicLit{Value: tc.vy.value},
+					Y:  &ast.BasicLit{Value: fmt.Sprintf("%v", tc.vy.value)},
 				}
-				name = fmt.Sprintf("%s %s %s", tc.vx.value, op, tc.vy.value)
+				name = fmt.Sprintf("%v %s %v", tc.vx.value, op, tc.vy.value)
 			)
 
 			t.Run(name, func(t *testing.T) {
@@ -99,8 +135,10 @@ func TestComparison(t *testing.T) {
 				if !errors.Is(tc.v.err, expectedErr) {
 					t.Fatalf("expected err: %v, got: %v", expectedErr, tc.v.err)
 				}
+
 				if tc.v.value != expectedValue {
-					t.Fatalf("expected value: %v, got: %v", expectedValue, tc.v.value)
+					t.Fatalf("expected value: %v (%T), got: %v (%T)", expectedValue, expectedValue,
+						tc.v.value, tc.v.value)
 				}
 			})
 		}

--- a/expr.go
+++ b/expr.go
@@ -3,7 +3,6 @@ package expr
 import (
 	"go/ast"
 	"go/parser"
-	"strconv"
 )
 
 // Any parses the given expr string into any type it returns as a result. e.g:
@@ -36,23 +35,24 @@ func Any(str string) (interface{}, error) {
 
 	switch v.Kind() {
 	case KindInt:
-		v, _ := strconv.ParseInt(v.Value(), 0, 64)
+		v := v.ValueAny().(int64)
 		return v, nil
 	case KindFloat:
-		v, _ := strconv.ParseFloat(v.Value(), 64)
+		v := v.ValueAny().(float64)
 		vInt := int64(v)
 		if v == float64(vInt) {
 			return vInt, nil
 		}
 		return v, nil
 	case KindImag:
-		v, _ := strconv.ParseComplex(v.Value(), 128)
+		v := v.ValueAny().(complex128)
 		return v, nil
 	case KindBoolean:
-		v, _ := strconv.ParseBool(v.Value())
+		v := v.ValueAny().(bool)
 		return v, nil
-	default:
-		return v.Value(), nil
+	default: // must be string
+		v := v.ValueAny().(string)
+		return v, nil
 	}
 }
 
@@ -86,7 +86,7 @@ func Bool(str string) (bool, error) {
 
 	switch v.kind {
 	case KindBoolean:
-		val, _ := strconv.ParseBool(v.Value())
+		val := v.ValueAny().(bool)
 		return val, nil
 	}
 
@@ -115,13 +115,13 @@ func Complex128(str string) (complex128, error) {
 
 	switch v.Kind() {
 	case KindImag:
-		v, _ := strconv.ParseComplex(v.Value(), 128)
+		v := v.ValueAny().(complex128)
 		return v, nil
 	case KindInt:
-		v, _ := strconv.ParseInt(v.Value(), 0, 64)
+		v := v.ValueAny().(int64)
 		return complex(float64(v), 0), nil
 	case KindFloat:
-		v, _ := strconv.ParseFloat(v.Value(), 64)
+		v := v.ValueAny().(float64)
 		return complex(v, 0), nil
 	}
 
@@ -151,10 +151,10 @@ func Float64(str string) (float64, error) {
 
 	switch v.Kind() {
 	case KindInt:
-		v, _ := strconv.ParseInt(v.Value(), 0, 64)
+		v := v.ValueAny().(int64)
 		return float64(v), nil
 	case KindFloat:
-		v, _ := strconv.ParseFloat(v.Value(), 64)
+		v := v.ValueAny().(float64)
 		return v, nil
 	}
 
@@ -205,10 +205,10 @@ func parseStringExprIntoInt64(str string, allowIntegerDividedByZero bool) (int64
 
 	switch v.Kind() {
 	case KindInt:
-		v, _ := strconv.ParseInt(v.Value(), 0, 64)
+		v := v.ValueAny().(int64)
 		return v, nil
 	case KindFloat:
-		v, _ := strconv.ParseFloat(v.Value(), 64)
+		v := v.ValueAny().(float64)
 		return int64(v), nil
 	}
 

--- a/expr.go
+++ b/expr.go
@@ -26,7 +26,10 @@ func Any(str string) (interface{}, error) {
 		return nil, err
 	}
 
-	v := NewVisitor()
+	v := NewVisitor(
+		WithAllowIntegerDividedByZero(true),
+		WithNumericType(NumericTypeAuto),
+	)
 	ast.Walk(v, expr)
 
 	if err := v.Err(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/muktihari/expr
 
 go 1.13
 
-require github.com/google/go-cmp v0.5.9 // indirect
+require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/logical.go
+++ b/logical.go
@@ -1,9 +1,9 @@
 package expr
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
-	"strconv"
 
 	"github.com/muktihari/expr/conv"
 )
@@ -19,22 +19,22 @@ func logical(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
 		return
 	}
 
-	x, _ := strconv.ParseBool(vx.value)
-	y, _ := strconv.ParseBool(vy.value)
+	x := vx.value.(bool)
+	y := vy.value.(bool)
 
 	v.kind = KindBoolean
 	if binaryExpr.Op == token.LAND {
-		v.value = strconv.FormatBool(x && y)
+		v.value = x && y
 		return
 	}
 
-	v.value = strconv.FormatBool(x || y) // token.LOR
+	v.value = x || y // token.LOR
 }
 
 func newLogicalNonBooleanError(v *Visitor, e ast.Expr) error {
 	s := conv.FormatExpr(e)
 	return &SyntaxError{
-		Msg: "result of \"" + s + "\" is \"" + v.value + "\" which is not a boolean",
+		Msg: "result of \"" + s + "\" is \"" + fmt.Sprintf("%v", v.value) + "\" which is not a boolean",
 		Pos: v.pos,
 		Err: ErrLogicalOperation,
 	}

--- a/logical_test.go
+++ b/logical_test.go
@@ -12,15 +12,15 @@ func TestLogical(t *testing.T) {
 	tt := []struct {
 		v, vx, vy      *Visitor
 		ops            []token.Token
-		expectedValues []string
+		expectedValues []interface{}
 		expectedErrs   []error
 	}{
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "true", kind: KindBoolean},
+			vx:             &Visitor{value: true, kind: KindBoolean},
 			ops:            []token.Token{token.LAND, token.NEQ},
-			vy:             &Visitor{value: "false", kind: KindBoolean},
-			expectedValues: []string{"false", "true"},
+			vy:             &Visitor{value: false, kind: KindBoolean},
+			expectedValues: []interface{}{false, true},
 			expectedErrs:   []error{nil, nil},
 		},
 		{
@@ -28,7 +28,7 @@ func TestLogical(t *testing.T) {
 			vx:             &Visitor{value: "1", kind: KindInt},
 			ops:            []token.Token{token.LAND},
 			vy:             &Visitor{value: "false", kind: KindBoolean},
-			expectedValues: []string{""},
+			expectedValues: []interface{}{nil},
 			expectedErrs:   []error{ErrLogicalOperation},
 		},
 		{
@@ -36,7 +36,7 @@ func TestLogical(t *testing.T) {
 			vx:             &Visitor{value: "false", kind: KindBoolean},
 			ops:            []token.Token{token.LAND},
 			vy:             &Visitor{value: "1", kind: KindInt},
-			expectedValues: []string{""},
+			expectedValues: []interface{}{nil},
 			expectedErrs:   []error{ErrLogicalOperation},
 		},
 	}
@@ -49,11 +49,11 @@ func TestLogical(t *testing.T) {
 				expectedErr   = tc.expectedErrs[i]
 				expectedValue = tc.expectedValues[i]
 				be            = &ast.BinaryExpr{
-					X:  &ast.BasicLit{Value: tc.vx.value},
+					X:  &ast.BasicLit{Value: fmt.Sprintf("%v", tc.vx.value)},
 					Op: op,
-					Y:  &ast.BasicLit{Value: tc.vy.value},
+					Y:  &ast.BasicLit{Value: fmt.Sprintf("%v", tc.vy.value)},
 				}
-				name = fmt.Sprintf("%s %s %s", tc.vx.value, op, tc.vy.value)
+				name = fmt.Sprintf("%v %s %v", tc.vx.value, op, tc.vy.value)
 			)
 
 			t.Run(name, func(t *testing.T) {

--- a/visitor.go
+++ b/visitor.go
@@ -225,7 +225,7 @@ func (v *Visitor) visitBasicLit(basicLit *ast.BasicLit) ast.Visitor {
 		v.value, _ = strconv.ParseFloat(basicLit.Value, 64)
 	case token.IMAG:
 		v.kind = KindImag
-		v.value, _ = strconv.ParseComplex(basicLit.Value, 64)
+		v.value, _ = strconv.ParseComplex(basicLit.Value, 128)
 	case token.CHAR:
 		fallthrough // treat as string
 	case token.STRING:

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -12,7 +12,7 @@ import (
 func TestVisit(t *testing.T) {
 	tt := []struct {
 		in            string
-		expectedValue string
+		expectedValue interface{}
 		expectedKind  expr.Kind
 		expectedErr   error
 	}{
@@ -23,37 +23,37 @@ func TestVisit(t *testing.T) {
 		},
 		{
 			in:            "'a' == 'a'",
-			expectedValue: "true",
+			expectedValue: true,
 			expectedKind:  expr.KindBoolean,
 		},
 		{
-			in:            "true && true",
-			expectedValue: "true",
-			expectedKind:  expr.KindBoolean,
+			in:            "-(20+10i)",
+			expectedValue: -(20 + 10i),
+			expectedKind:  expr.KindImag,
 		},
 		{
 			in:            "true && 20 > 9",
-			expectedValue: "true",
+			expectedValue: true,
 			expectedKind:  expr.KindBoolean,
 		},
 		{
 			in:            "1 + 1",
-			expectedValue: "2",
+			expectedValue: float64(2),
 			expectedKind:  expr.KindFloat,
 		},
 		{
 			in:            "1 + 2 * 10",
-			expectedValue: "21",
+			expectedValue: float64(21),
 			expectedKind:  expr.KindFloat,
 		},
 		{
 			in:            "2.5 * 2.1",
-			expectedValue: "5.25",
+			expectedValue: float64(5.25),
 			expectedKind:  expr.KindFloat,
 		},
 		{
 			in:            "2.50 > 2.4",
-			expectedValue: "true",
+			expectedValue: true,
 			expectedKind:  expr.KindBoolean,
 		},
 		{
@@ -63,7 +63,7 @@ func TestVisit(t *testing.T) {
 		},
 		{
 			in:            "4 == 0b0100",
-			expectedValue: "true",
+			expectedValue: true,
 			expectedKind:  expr.KindBoolean,
 		},
 		{
@@ -78,7 +78,7 @@ func TestVisit(t *testing.T) {
 		},
 		{
 			in:            "expr == expr",
-			expectedValue: "true",
+			expectedValue: true,
 			expectedKind:  expr.KindBoolean,
 		},
 	}
@@ -97,8 +97,8 @@ func TestVisit(t *testing.T) {
 			if err := v.Err(); !errors.Is(err, tc.expectedErr) {
 				t.Fatalf("expected err: %v, got: %v", tc.expectedErr, err)
 			}
-			if val := v.Value(); val != tc.expectedValue {
-				t.Fatalf("expected val: %v, got: %v", tc.expectedValue, val)
+			if val := v.ValueAny(); val != tc.expectedValue {
+				t.Fatalf("expected val: %v (%T), got: %v (%T)", tc.expectedValue, tc.expectedValue, val, val)
 			}
 			if kind := v.Kind(); kind != tc.expectedKind {
 				t.Fatalf("expected kind: %v, got: %v", tc.expectedKind, kind)
@@ -132,7 +132,7 @@ func TestVisit(t *testing.T) {
 				t.Fatalf("expected kind: %s, got: %s", tc.expected.Kind(), v.Kind())
 			}
 			if v.Value() != tc.expected.Value() {
-				t.Fatalf("expected value: %s, got: %s", tc.expected.Value(), v.Value())
+				t.Fatalf("expected value: %v, got: %v", tc.expected.Value(), v.Value())
 			}
 		})
 	}


### PR DESCRIPTION
- Change underlying value from string to interface value, reducing unnecessary string conversion overhead.
- Use sync.Pool to handle Visitor creation to reduce allocs, instead of creating new Visitor each Visit, we can use existing Visitors. Look at this code example, after `Visitor X` finish visiting, `Visitor Y` might reuse Visitors created during previous `Visitor X`'s Visit. This will happen recursively. And also, next time user trigger any `expr` function, chances are they can ruse existing Visitor objects from previous invocation, only if it is still being kept alive by sync.Pool.
```go
func (v *Visitor) visitBinary(binaryExpr *ast.BinaryExpr) ast.Visitor {
    vx := visitorPool.Get().(*Visitor)
    defer visitorPool.Put(vx)
    vx.reset()
    vx.options = v.options

    ast.Walk(vx, binaryExpr.X)
    if vx.err != nil {
         v.err = vx.err
        return nil
    }

    /* Visitor Y might reuse existing Visitor objects created during Visitor X's Visit 
       (or from previous invocation) */
    vy := visitorPool.Get().(*Visitor)
    defer visitorPool.Put(vy)
    vy.reset()
    vy.options = v.options

    ast.Walk(vy, binaryExpr.Y)
    if vy.err != nil {
        v.err = vy.err
        return nil
    }
...
```

Here is the `benchstat` from old Version that use string with this new Version using interface plus sync.Pool.

```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/expr
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                  │    old.txt    │               xxx.txt                │
                  │    sec/op     │    sec/op     vs base                │
Any/KindBoolean-4    13.51µ ±  3%   13.28µ ± 31%        ~ (p=0.631 n=10)
Any/KindInt-4        7.053µ ± 60%   5.364µ ± 14%  -23.94% (p=0.000 n=10)
Any/KindFloat-4     11.209µ ±  4%   9.288µ ± 31%  -17.14% (p=0.029 n=10)
Any/KindImag-4       9.600µ ± 72%   5.651µ ± 17%  -41.14% (p=0.000 n=10)
geomean              10.06µ         7.819µ        -22.29%

                  │   old.txt    │               xxx.txt                │
                  │     B/op     │     B/op      vs base                │
Any/KindBoolean-4   5.297Ki ± 0%   2.734Ki ± 0%  -48.38% (p=0.000 n=10)
Any/KindInt-4       2.664Ki ± 0%   1.562Ki ± 0%  -41.35% (p=0.000 n=10)
Any/KindFloat-4     3.844Ki ± 0%   2.047Ki ± 0%  -46.75% (p=0.000 n=10)
Any/KindImag-4      2.719Ki ± 0%   1.641Ki ± 0%  -39.66% (p=0.000 n=10)
geomean             3.485Ki        1.946Ki       -44.15%

                  │   old.txt   │              xxx.txt               │
                  │  allocs/op  │ allocs/op   vs base                │
Any/KindBoolean-4   111.00 ± 0%   72.00 ± 0%  -35.14% (p=0.000 n=10)
Any/KindInt-4        62.00 ± 0%   44.00 ± 0%  -29.03% (p=0.000 n=10)
Any/KindFloat-4      91.00 ± 0%   61.00 ± 0%  -32.97% (p=0.000 n=10)
Any/KindImag-4       77.00 ± 0%   49.00 ± 0%  -36.36% (p=0.000 n=10)
geomean              83.33        55.47       -33.43%

```