### PR TITLE
perf: implement custom value to reduce memory allocation

### DIFF
--- a/arithmetic_test.go
+++ b/arithmetic_test.go
@@ -29,103 +29,106 @@ func TestArithmetic(t *testing.T) {
 		name          string
 		v, vx, vy     *Visitor
 		op            token.Token
-		expectedValue interface{}
+		expectedValue value
 		expectedErr   error
 	}{
 		{
 			name:          "arithmetic non numeric error: x numeric y boolean",
 			v:             newVisitor(NumericTypeAuto),
-			vx:            &Visitor{value: int64(1), kind: KindInt},
-			vy:            &Visitor{value: true, kind: KindBoolean},
+			vx:            &Visitor{value: int64Value(1)},
+			vy:            &Visitor{value: boolValue(true)},
 			op:            token.ADD,
-			expectedValue: nil,
+			expectedValue: value{},
 			expectedErr:   ErrArithmeticOperation,
 		},
 		{
 			name:          "arithmetic non numeric error: x boolean y numeric",
 			v:             newVisitor(NumericTypeAuto),
-			vx:            &Visitor{value: false, kind: KindBoolean},
-			vy:            &Visitor{value: int64(10), kind: KindInt},
+			vx:            &Visitor{value: boolValue(false)},
+			vy:            &Visitor{value: int64Value(10)},
 			op:            token.ADD,
-			expectedValue: nil,
+			expectedValue: value{},
 			expectedErr:   ErrArithmeticOperation,
 		},
 		{
 			name:          "arithmetic numeric complex",
 			v:             newVisitor(NumericTypeComplex),
-			vx:            &Visitor{value: (1 + 0i), kind: KindImag},
-			vy:            &Visitor{value: int64(2), kind: KindInt},
+			vx:            &Visitor{value: complex128Value(1 + 0i)},
+			vy:            &Visitor{value: int64Value(2)},
 			op:            token.ADD,
-			expectedValue: (3 + 0i),
+			expectedValue: complex128Value(3 + 0i),
 		},
 		{
 			name:          "arithmetic numeric float",
 			v:             newVisitor(NumericTypeFloat),
-			vx:            &Visitor{value: float64(1.5), kind: KindFloat},
-			vy:            &Visitor{value: int64(2), kind: KindInt},
+			vx:            &Visitor{value: float64Value(1.5)},
+			vy:            &Visitor{value: int64Value(2)},
 			op:            token.ADD,
-			expectedValue: 3.5,
+			expectedValue: float64Value(3.5),
 		},
 		{
 			name:          "arithmetic numeric int",
 			v:             newVisitor(NumericTypeInt),
-			vx:            &Visitor{value: float64(1.5), kind: KindFloat},
-			vy:            &Visitor{value: int64(2), kind: KindInt},
+			vx:            &Visitor{value: float64Value(1.5)},
+			vy:            &Visitor{value: int64Value(2)},
 			op:            token.ADD,
-			expectedValue: int64(3),
+			expectedValue: int64Value(3),
 		},
 		{
 			name:          "arithmetic numeric auto: x imag y int",
 			v:             newVisitor(NumericTypeAuto),
-			vx:            &Visitor{value: (1.5 + 1i), kind: KindImag},
-			vy:            &Visitor{value: int64(2), kind: KindInt},
+			vx:            &Visitor{value: complex128Value(1.5 + 1i)},
+			vy:            &Visitor{value: int64Value(2)},
 			op:            token.ADD,
-			expectedValue: (3.5 + 1i),
+			expectedValue: complex128Value(3.5 + 1i),
 		},
 		{
 			name:          "arithmetic numeric auto: x int y imag",
 			v:             newVisitor(NumericTypeAuto),
-			vx:            &Visitor{value: int64(2), kind: KindInt},
-			vy:            &Visitor{value: (1.5 + 1i), kind: KindImag},
+			vx:            &Visitor{value: int64Value(2)},
+			vy:            &Visitor{value: complex128Value(1.5 + 1i)},
 			op:            token.ADD,
-			expectedValue: (3.5 + 1i),
+			expectedValue: complex128Value(3.5 + 1i),
 		},
 		{
 			name:          "arithmetic numeric auto: x float y int",
 			v:             newVisitor(NumericTypeAuto),
-			vx:            &Visitor{value: float64(1.5), kind: KindFloat},
-			vy:            &Visitor{value: int64(2), kind: KindInt},
+			vx:            &Visitor{value: float64Value(1.5)},
+			vy:            &Visitor{value: int64Value(2)},
 			op:            token.ADD,
-			expectedValue: float64(3.5),
+			expectedValue: float64Value(3.5),
 		},
 		{
 			name:          "arithmetic numeric auto: x int y float",
 			v:             newVisitor(NumericTypeAuto),
-			vx:            &Visitor{value: float64(1.5), kind: KindFloat},
-			vy:            &Visitor{value: int64(2), kind: KindInt},
+			vx:            &Visitor{value: float64Value(1.5)},
+			vy:            &Visitor{value: int64Value(2)},
 			op:            token.ADD,
-			expectedValue: float64(3.5),
+			expectedValue: float64Value(3.5),
 		},
 		{
 			name:          "arithmetic numeric auto: x int y int",
 			v:             newVisitor(NumericTypeAuto),
-			vx:            &Visitor{value: int64(1), kind: KindInt},
-			vy:            &Visitor{value: int64(2), kind: KindInt},
+			vx:            &Visitor{value: int64Value(1)},
+			vy:            &Visitor{value: int64Value(2)},
 			op:            token.ADD,
-			expectedValue: float64(3),
+			expectedValue: float64Value(3),
 		},
 	}
 
-	for _, tc := range tt {
+	for i, tc := range tt {
+		if i < 2 {
+			continue
+		}
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			be := &ast.BinaryExpr{Op: tc.op}
 			arithmetic(tc.v, tc.vx, tc.vy, be)
 			if !errors.Is(tc.v.err, tc.expectedErr) {
 				t.Fatalf("expected err: %v, got: %v", tc.expectedErr, tc.v.err)
 			}
-			if tc.v.value != tc.expectedValue {
-				t.Fatalf("expected value: %v (%T), got: %v (%T)", tc.expectedValue, tc.expectedValue,
+			if tc.v.value.Any() != tc.expectedValue.Any() {
+				t.Fatalf("expected value: %v (%T), got: %v (%T)", tc.expectedValue.Any(), tc.expectedValue.Any(),
 					tc.v.value, tc.v.value)
 			}
 		})
@@ -140,43 +143,43 @@ func TestCalculateComplex(t *testing.T) {
 		name           string
 		v, vx, vy      *Visitor
 		ops            []token.Token
-		expectedValues []interface{}
+		expectedValues []value
 		expectedErrs   []error
 	}{
 		{
 			name:           "calculate integers",
 			v:              newComplexVisitor(),
-			vx:             &Visitor{value: int64(1), kind: KindInt},
-			vy:             &Visitor{value: int64(2), kind: KindInt},
+			vx:             &Visitor{value: int64Value(1)},
+			vy:             &Visitor{value: int64Value(2)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO},
-			expectedValues: []interface{}{(3 + 0i), (-1 + 0i), (2 + 0i), (0.5 + 0i)},
+			expectedValues: []value{complex128Value(3 + 0i), complex128Value(-1 + 0i), complex128Value(2 + 0i), complex128Value(0.5 + 0i)},
 			expectedErrs:   []error{nil, nil, nil, nil},
 		},
 		{
 			name:           "calculate floats",
 			v:              newComplexVisitor(),
-			vx:             &Visitor{value: float64(1.0), kind: KindFloat},
-			vy:             &Visitor{value: float64(2.0), kind: KindFloat},
+			vx:             &Visitor{value: float64Value(1.0)},
+			vy:             &Visitor{value: float64Value(2.0)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO},
-			expectedValues: []interface{}{(3 + 0i), (-1 + 0i), (2 + 0i), (0.5 + 0i)},
+			expectedValues: []value{complex128Value(3 + 0i), complex128Value(-1 + 0i), complex128Value(2 + 0i), complex128Value(0.5 + 0i)},
 			expectedErrs:   []error{nil, nil, nil, nil},
 		},
 		{
 			name:           "calculate complex numbers",
 			v:              newComplexVisitor(),
-			vx:             &Visitor{value: (1 + 1i), kind: KindImag},
-			vy:             &Visitor{value: (2 + 1i), kind: KindImag},
+			vx:             &Visitor{value: complex128Value(1 + 1i)},
+			vy:             &Visitor{value: complex128Value(2 + 1i)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO},
-			expectedValues: []interface{}{(3 + 2i), (-1 + 0i), (1 + 3i), (0.6 + 0.2i)},
+			expectedValues: []value{complex128Value(3 + 2i), complex128Value(-1 + 0i), complex128Value(1 + 3i), complex128Value(0.6 + 0.2i)},
 			expectedErrs:   []error{nil, nil, nil, nil},
 		},
 		{
 			name:           "unsupported complex operation",
 			v:              newComplexVisitor(),
-			vx:             &Visitor{value: (1 + 1i), kind: KindImag},
-			vy:             &Visitor{value: (2 + 1i), kind: KindImag},
+			vx:             &Visitor{value: complex128Value(1 + 1i)},
+			vy:             &Visitor{value: complex128Value(2 + 1i)},
 			ops:            []token.Token{token.REM},
-			expectedValues: []interface{}{nil},
+			expectedValues: []value{{}},
 			expectedErrs:   []error{ErrArithmeticOperation},
 		},
 	}
@@ -186,15 +189,15 @@ func TestCalculateComplex(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for i, op := range tc.ops {
 				i, op := i, op
-				name := fmt.Sprintf("%v%s%v", tc.vx.value, op, tc.vy.value)
+				name := fmt.Sprintf("%v%s%v", tc.vx.value.Any(), op, tc.vy.value.Any())
 				t.Run(name, func(t *testing.T) {
 					be := &ast.BinaryExpr{Op: op}
 					calculateComplex(tc.v, parseComplex(tc.vx.value), parseComplex(tc.vy.value), be.Op, be.OpPos)
 					if !errors.Is(tc.v.err, tc.expectedErrs[i]) {
 						t.Fatalf("expected err: %v, got: %v", tc.expectedErrs[i], tc.v.err)
 					}
-					if tc.v.value != tc.expectedValues[i] {
-						t.Fatalf("expected value: %v (%T), got: % (%T)", tc.expectedValues[i], tc.expectedValues[i],
+					if tc.v.value.Any() != tc.expectedValues[i].Any() {
+						t.Fatalf("expected value: %v (%T), got: %v (%T)", tc.expectedValues[i].Any(), tc.expectedValues[i].Any(),
 							tc.v.value, tc.v.value)
 					}
 				})
@@ -212,34 +215,34 @@ func TestCalculateFloat(t *testing.T) {
 		name           string
 		v, vx, vy      *Visitor
 		ops            []token.Token
-		expectedValues []interface{}
+		expectedValues []value
 		expectedErrs   []error
 	}{
 		{
 			name:           "calculate integers",
 			v:              newFloatVisitor(),
-			vx:             &Visitor{value: int64(10), kind: KindInt},
-			vy:             &Visitor{value: int64(3), kind: KindInt},
+			vx:             &Visitor{value: int64Value(10)},
+			vy:             &Visitor{value: int64Value(3)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO, token.REM},
-			expectedValues: []interface{}{float64(13), float64(7), float64(30), float64(3.3333333333333335), float64(1)},
+			expectedValues: []value{float64Value(13), float64Value(7), float64Value(30), float64Value(3.3333333333333335), float64Value(1)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil},
 		},
 		{
 			name:           "calculate floats",
 			v:              newFloatVisitor(),
-			vx:             &Visitor{value: float64(10.0), kind: KindFloat},
-			vy:             &Visitor{value: float64(3.0), kind: KindFloat},
+			vx:             &Visitor{value: float64Value(10.0)},
+			vy:             &Visitor{value: float64Value(3.0)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO, token.REM},
-			expectedValues: []interface{}{float64(13), float64(7), float64(30), float64(3.3333333333333335), float64(1)},
+			expectedValues: []value{float64Value(13), float64Value(7), float64Value(30), float64Value(3.3333333333333335), float64Value(1)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil},
 		},
 		{
 			name:           "calculate complex numbers",
 			v:              newFloatVisitor(),
-			vx:             &Visitor{value: (10 + 1i), kind: KindImag},
-			vy:             &Visitor{value: (3 + 1i), kind: KindImag},
+			vx:             &Visitor{value: complex128Value(10 + 1i)},
+			vy:             &Visitor{value: complex128Value(3 + 1i)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO, token.REM},
-			expectedValues: []interface{}{float64(13), float64(7), float64(30), float64(3.3333333333333335), float64(1)},
+			expectedValues: []value{float64Value(13), float64Value(7), float64Value(30), float64Value(3.3333333333333335), float64Value(1)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil},
 		},
 	}
@@ -249,15 +252,15 @@ func TestCalculateFloat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for i, op := range tc.ops {
 				i, op := i, op
-				name := fmt.Sprintf("%v%s%v", tc.vx.value, op, tc.vy.value)
+				name := fmt.Sprintf("%v%s%v", tc.vx.value.Any(), op, tc.vy.value.Any())
 				t.Run(name, func(t *testing.T) {
 					be := &ast.BinaryExpr{Op: op}
 					calculateFloat(tc.v, parseFloat(tc.vx.value), parseFloat(tc.vy.value), be.Op)
 					if !errors.Is(tc.v.err, tc.expectedErrs[i]) {
 						t.Fatalf("expected err: %v, got: %v", tc.expectedErrs[i], tc.v.err)
 					}
-					if tc.v.value != tc.expectedValues[i] {
-						t.Fatalf("expected value: %v (%T), got: %s (%T)", tc.expectedValues[i], tc.expectedValues[i],
+					if tc.v.value.Any() != tc.expectedValues[i].Any() {
+						t.Fatalf("expected value: %v (%T), got: %v (%T)", tc.expectedValues[i].Any(), tc.expectedValues[i].Any(),
 							tc.v.value, tc.v.value)
 					}
 				})
@@ -278,52 +281,52 @@ func TestCalculateInt(t *testing.T) {
 		name           string
 		v, vx, vy      *Visitor
 		ops            []token.Token
-		expectedValues []interface{}
+		expectedValues []value
 		expectedErrs   []error
 	}{
 		{
 			name:           "calculate integers",
 			v:              newIntVisitor(),
-			vx:             &Visitor{value: int64(10), kind: KindInt},
-			vy:             &Visitor{value: int64(3), kind: KindInt},
+			vx:             &Visitor{value: int64Value(10)},
+			vy:             &Visitor{value: int64Value(3)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO, token.REM},
-			expectedValues: []interface{}{int64(13), int64(7), int64(30), int64(3), int64(1)},
+			expectedValues: []value{int64Value(13), int64Value(7), int64Value(30), int64Value(3), int64Value(1)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil},
 		},
 		{
 			name:           "calculate integers allowIntegerDividedByZero == true",
 			v:              &Visitor{options: options{numericType: NumericTypeInt, allowIntegerDividedByZero: true}},
-			vx:             &Visitor{value: int64(10), kind: KindInt},
-			vy:             &Visitor{value: int64(0), kind: KindInt},
+			vx:             &Visitor{value: int64Value(10)},
+			vy:             &Visitor{value: int64Value(0)},
 			ops:            []token.Token{token.QUO},
-			expectedValues: []interface{}{int64(0)},
+			expectedValues: []value{int64Value(0)},
 			expectedErrs:   []error{nil},
 		},
 		{
 			name:           "calculate integers allowIntegerDividedByZero == false",
 			v:              &Visitor{options: options{numericType: NumericTypeInt, allowIntegerDividedByZero: false}},
-			vx:             &Visitor{value: int64(10), kind: KindInt},
-			vy:             &Visitor{value: int64(0), kind: KindInt},
+			vx:             &Visitor{value: int64Value(10)},
+			vy:             &Visitor{value: int64Value(0)},
 			ops:            []token.Token{token.QUO},
-			expectedValues: []interface{}{nil},
+			expectedValues: []value{{}},
 			expectedErrs:   []error{ErrIntegerDividedByZero},
 		},
 		{
 			name:           "calculate floats",
 			v:              newIntVisitor(),
-			vx:             &Visitor{value: float64(10.0), kind: KindFloat},
-			vy:             &Visitor{value: float64(3.0), kind: KindFloat},
+			vx:             &Visitor{value: float64Value(10.0)},
+			vy:             &Visitor{value: float64Value(3.0)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO, token.REM},
-			expectedValues: []interface{}{int64(13), int64(7), int64(30), int64(3), int64(1)},
+			expectedValues: []value{int64Value(13), int64Value(7), int64Value(30), int64Value(3), int64Value(1)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil},
 		},
 		{
 			name:           "calculate complex numbers",
 			v:              newIntVisitor(),
-			vx:             &Visitor{value: (10 + 1i), kind: KindImag},
-			vy:             &Visitor{value: (3 + 1i), kind: KindImag},
+			vx:             &Visitor{value: complex128Value(10 + 1i)},
+			vy:             &Visitor{value: complex128Value(3 + 1i)},
 			ops:            []token.Token{token.ADD, token.SUB, token.MUL, token.QUO, token.REM},
-			expectedValues: []interface{}{int64(13), int64(7), int64(30), int64(3), int64(1)},
+			expectedValues: []value{int64Value(13), int64Value(7), int64Value(30), int64Value(3), int64Value(1)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil},
 		},
 	}
@@ -333,15 +336,15 @@ func TestCalculateInt(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for i, op := range tc.ops {
 				i, op := i, op
-				name := fmt.Sprintf("%v%s%v", tc.vx.value, op, tc.vy.value)
+				name := fmt.Sprintf("%v%s%v", tc.vx.value.Any(), op, tc.vy.value.Any())
 				t.Run(name, func(t *testing.T) {
 					be := &ast.BinaryExpr{Op: op}
 					calculateInt(tc.v, parseInt(tc.vx.value), parseInt(tc.vy.value), tc.vy.pos, be.Op)
 					if !errors.Is(tc.v.err, tc.expectedErrs[i]) {
 						t.Fatalf("expected err: %v, got: %v", tc.expectedErrs[i], tc.v.err)
 					}
-					if tc.v.value != tc.expectedValues[i] {
-						t.Fatalf("expected value: %v (%T), got: %v (%T)", tc.expectedValues[i], tc.expectedValues[i],
+					if tc.v.value.Any() != tc.expectedValues[i].Any() {
+						t.Fatalf("expected value: %v (%T), got: %v (%T)", tc.expectedValues[i].Any(), tc.expectedValues[i].Any(),
 							tc.v.value, tc.v.value)
 					}
 				})
@@ -351,15 +354,15 @@ func TestCalculateInt(t *testing.T) {
 }
 
 func TestParseInvalidValue(t *testing.T) {
-	i64 := parseInt("invalid")
+	i64 := parseInt(stringValue("invalid"))
 	if i64 != 0 {
 		t.Fatalf("expected 0, got: %v", i64)
 	}
-	f64 := parseFloat(true)
+	f64 := parseFloat(boolValue(true))
 	if f64 != 0 {
 		t.Fatalf("expected 0, got: %v", f64)
 	}
-	c128 := parseComplex(false)
+	c128 := parseComplex(boolValue(false))
 	if c128 != 0 {
 		t.Fatalf("expected 0, got: %v", c128)
 	}

--- a/arithmetic_test.go
+++ b/arithmetic_test.go
@@ -117,9 +117,6 @@ func TestArithmetic(t *testing.T) {
 	}
 
 	for i, tc := range tt {
-		if i < 2 {
-			continue
-		}
 		tc := tc
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			be := &ast.BinaryExpr{Op: tc.op}

--- a/bitwise_test.go
+++ b/bitwise_test.go
@@ -30,99 +30,99 @@ func TestBitwise(t *testing.T) {
 	}{
 		{
 			v:           &Visitor{options: options{numericType: NumericTypeFloat}},
-			vx:          &Visitor{value: int64(0b1000), kind: KindInt},
-			vy:          &Visitor{value: int64(0b1001), kind: KindInt},
+			vx:          &Visitor{value: int64Value(0b1000)},
+			vy:          &Visitor{value: int64Value(0b1001)},
 			op:          token.AND, // "&"
 			expectedErr: ErrBitwiseOperation,
 		},
 		{
 			v:           &Visitor{},
-			vx:          &Visitor{value: float64(2.0), kind: KindFloat},
-			vy:          &Visitor{value: int64(0b1001), kind: KindInt},
+			vx:          &Visitor{value: float64Value(2.0)},
+			vy:          &Visitor{value: int64Value(0b1001)},
 			op:          token.AND, // "&"
 			expectedErr: nil,
 		},
 		{
 			v:           &Visitor{},
-			vx:          &Visitor{value: float64(2.2), kind: KindFloat},
-			vy:          &Visitor{value: int64(0b1001), kind: KindInt},
+			vx:          &Visitor{value: float64Value(2.2)},
+			vy:          &Visitor{value: int64Value(0b1001)},
 			op:          token.AND, // "&"
 			expectedErr: ErrBitwiseOperation,
 		},
 		{
 			v:           &Visitor{},
-			vx:          &Visitor{value: int64(0b1001), kind: KindInt},
-			vy:          &Visitor{value: float64(2.0), kind: KindFloat},
+			vx:          &Visitor{value: int64Value(0b1001)},
+			vy:          &Visitor{value: float64Value(2.0)},
 			op:          token.AND, // "&"
 			expectedErr: nil,
 		},
 		{
 			v:           &Visitor{},
-			vx:          &Visitor{value: int64(0b1001), kind: KindInt},
-			vy:          &Visitor{value: float64(2.2), kind: KindFloat},
+			vx:          &Visitor{value: int64Value(0b1001)},
+			vy:          &Visitor{value: float64Value(2.2)},
 			op:          token.AND, // "&"
 			expectedErr: ErrBitwiseOperation,
 		},
 		{
 			v:             &Visitor{},
-			vx:            &Visitor{value: int64(0b1000), kind: KindInt},
-			vy:            &Visitor{value: int64(0b1001), kind: KindInt},
+			vx:            &Visitor{value: int64Value(0b1000)},
+			vy:            &Visitor{value: int64Value(0b1001)},
 			op:            token.AND, // "&"
 			expectedValue: int64(0b1000),
 		},
 		{
 			v:             &Visitor{},
-			vx:            &Visitor{value: int64(0b1000), kind: KindInt},
-			vy:            &Visitor{value: int64(0b0001), kind: KindInt},
+			vx:            &Visitor{value: int64Value(0b1000)},
+			vy:            &Visitor{value: int64Value(0b0001)},
 			op:            token.OR, // "|"
 			expectedValue: int64(0b1001),
 		},
 		{
 			v:             &Visitor{},
-			vx:            &Visitor{value: int64(0b1000), kind: KindInt},
-			vy:            &Visitor{value: int64(0b1001), kind: KindInt},
+			vx:            &Visitor{value: int64Value(0b1000)},
+			vy:            &Visitor{value: int64Value(0b1001)},
 			op:            token.XOR, // "^"
 			expectedValue: int64(0b0001),
 		},
 		{
 			v:             &Visitor{},
-			vx:            &Visitor{value: int64(0b1100), kind: KindInt},
-			vy:            &Visitor{value: int64(0b0101), kind: KindInt},
+			vx:            &Visitor{value: int64Value(0b1100)},
+			vy:            &Visitor{value: int64Value(0b0101)},
 			op:            token.AND_NOT, // "&^"
 			expectedValue: int64(0b1000),
 		},
 		{
 			v:             &Visitor{},
-			vx:            &Visitor{value: int64(0b1001), kind: KindInt},
-			vy:            &Visitor{value: int64(0b0001), kind: KindInt},
+			vx:            &Visitor{value: int64Value(0b1001)},
+			vy:            &Visitor{value: int64Value(0b0001)},
 			op:            token.SHL, // "<<"
 			expectedValue: int64(0b10010),
 		},
 		{
 			v:             &Visitor{},
-			vx:            &Visitor{value: int64(0b1000), kind: KindInt},
-			vy:            &Visitor{value: int64(0b0001), kind: KindInt},
+			vx:            &Visitor{value: int64Value(0b1000)},
+			vy:            &Visitor{value: int64Value(0b0001)},
 			op:            token.SHR, // ">>"
 			expectedValue: int64(0b0100),
 		},
 		{
 			v:             &Visitor{},
-			vx:            &Visitor{value: float64(4.0), kind: KindFloat},
-			vy:            &Visitor{value: int64(10), kind: KindInt},
+			vx:            &Visitor{value: float64Value(4.0)},
+			vy:            &Visitor{value: int64Value(10)},
 			op:            token.SHL, // "<<"
 			expectedValue: int64(0b1000000000000),
 		},
 		{
 			v:           &Visitor{},
-			vx:          &Visitor{value: true, kind: KindBoolean},
-			vy:          &Visitor{value: int64(10), kind: KindInt},
+			vx:          &Visitor{value: boolValue(true)},
+			vy:          &Visitor{value: int64Value(10)},
 			op:          token.SHL, // "<<"
 			expectedErr: ErrBitwiseOperation,
 		},
 		{
 			v:           &Visitor{},
-			vx:          &Visitor{value: int64(10), kind: KindInt},
-			vy:          &Visitor{value: true, kind: KindBoolean},
+			vx:          &Visitor{value: int64Value(10)},
+			vy:          &Visitor{value: boolValue(true)},
 			op:          token.SHL, // "<<"
 			expectedErr: ErrBitwiseOperation,
 		},
@@ -130,7 +130,7 @@ func TestBitwise(t *testing.T) {
 
 	for _, tc := range tt {
 		tc := tc
-		name := fmt.Sprintf("%v %s %v", tc.vx.value, tc.op, tc.vy.value)
+		name := fmt.Sprintf("%v %s %v", tc.vx.value.Any(), tc.op, tc.vy.value.Any())
 		t.Run(name, func(t *testing.T) {
 			opPos := token.Pos(len(fmt.Sprintf("%v", tc.vx.value)) + 1)
 			be := &ast.BinaryExpr{
@@ -145,7 +145,7 @@ func TestBitwise(t *testing.T) {
 				t.Fatalf("expected err: %v, got: %v", tc.expectedErr, tc.v.err)
 			}
 
-			value, _ := tc.v.value.(int64)
+			value := tc.v.value.Int64()
 			if value != tc.expectedValue {
 				t.Fatalf("expected value: %v (%T), got: %v (%T)", tc.expectedValue, tc.expectedValue,
 					tc.v.value, tc.v.value)

--- a/comparison_test.go
+++ b/comparison_test.go
@@ -173,9 +173,6 @@ func TestComparison(t *testing.T) {
 	}
 
 	for i, tc := range tt {
-		if i < 3 {
-			continue
-		}
 		tc := tc
 
 		for j, op := range tc.ops {

--- a/comparison_test.go
+++ b/comparison_test.go
@@ -25,177 +25,180 @@ func TestComparison(t *testing.T) {
 	tt := []struct {
 		v, vx, vy      *Visitor
 		ops            []token.Token
-		expectedValues []interface{}
+		expectedValues []value
 		expectedErrs   []error
 	}{
 		// compareBoolean
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: true, kind: KindBoolean},
+			vx:             &Visitor{value: boolValue(true)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: false, kind: KindBoolean},
-			expectedValues: []interface{}{false, true},
+			vy:             &Visitor{value: boolValue(false)},
+			expectedValues: []value{boolValue(false), boolValue(true)},
 			expectedErrs:   []error{nil, nil},
 		},
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: true, kind: KindBoolean},
+			vx:             &Visitor{value: boolValue(true)},
 			ops:            []token.Token{token.GTR},
-			vy:             &Visitor{value: false, kind: KindBoolean},
-			expectedValues: []interface{}{nil},
+			vy:             &Visitor{value: boolValue(false)},
+			expectedValues: []value{{}},
 			expectedErrs:   []error{ErrUnsupportedOperator},
 		},
 		// compareString
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "\"abc\"", kind: KindString},
+			vx:             &Visitor{value: stringValue("\"abc\"")},
 			ops:            []token.Token{token.EQL, token.NEQ, token.GTR, token.GEQ, token.LSS, token.LEQ},
-			vy:             &Visitor{value: "\"abc\"", kind: KindString},
-			expectedValues: []interface{}{true, false, false, true, false, true},
+			vy:             &Visitor{value: stringValue("\"abc\"")},
+			expectedValues: []value{boolValue(true), boolValue(false), boolValue(false), boolValue(true), boolValue(false), boolValue(true)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil, nil},
 		},
 		// compareImag
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: (2 + 0i), kind: KindImag},
+			vx:             &Visitor{value: complex128Value(2 + 0i)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: (2 + 0i), kind: KindImag},
-			expectedValues: []interface{}{true, false},
+			vy:             &Visitor{value: complex128Value(2 + 0i)},
+			expectedValues: []value{boolValue(true), boolValue(false)},
 			expectedErrs:   []error{nil, nil},
 		},
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: (2 + 0i), kind: KindImag},
+			vx:             &Visitor{value: complex128Value(2 + 0i)},
 			ops:            []token.Token{token.GTR},
-			vy:             &Visitor{value: (2 + 0i), kind: KindImag},
-			expectedValues: []interface{}{nil},
+			vy:             &Visitor{value: complex128Value(2 + 0i)},
+			expectedValues: []value{{}},
 			expectedErrs:   []error{ErrUnsupportedOperator},
 		},
 		// compareFloat
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: float64(2.0), kind: KindFloat},
+			vx:             &Visitor{value: float64Value(2.0)},
 			ops:            []token.Token{token.EQL, token.NEQ, token.GTR, token.GEQ, token.LSS, token.LEQ},
-			vy:             &Visitor{value: int64(2), kind: KindInt},
-			expectedValues: []interface{}{true, false, false, true, false, true},
+			vy:             &Visitor{value: int64Value(2)},
+			expectedValues: []value{boolValue(true), boolValue(false), boolValue(false), boolValue(true), boolValue(false), boolValue(true)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil, nil},
 		},
 		// compareInt
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: int64(2), kind: KindInt},
+			vx:             &Visitor{value: int64Value(2)},
 			ops:            []token.Token{token.EQL, token.NEQ, token.GTR, token.GEQ, token.LSS, token.LEQ},
-			vy:             &Visitor{value: int64(2), kind: KindInt},
-			expectedValues: []interface{}{true, false, false, true, false, true},
+			vy:             &Visitor{value: int64Value(2)},
+			expectedValues: []value{boolValue(true), boolValue(false), boolValue(false), boolValue(true), boolValue(false), boolValue(true)},
 			expectedErrs:   []error{nil, nil, nil, nil, nil, nil},
 		},
 		// compare imag to float
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: (2 + 0i), kind: KindImag},
+			vx:             &Visitor{value: complex128Value(2 + 0i)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: 2.0, kind: KindFloat},
-			expectedValues: []interface{}{true, false},
+			vy:             &Visitor{value: float64Value(2.0)},
+			expectedValues: []value{boolValue(true), boolValue(false)},
 			expectedErrs:   []error{nil, nil},
 		},
 		// compare imag to int
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: (2 + 0i), kind: KindImag},
+			vx:             &Visitor{value: complex128Value(2 + 0i)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: int64(2), kind: KindInt},
-			expectedValues: []interface{}{true, false},
+			vy:             &Visitor{value: int64Value(2)},
+			expectedValues: []value{boolValue(true), boolValue(false)},
 			expectedErrs:   []error{nil, nil},
 		},
 		// compare float to imag
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: 2.0, kind: KindInt},
+			vx:             &Visitor{value: float64Value(2.0)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: (2 + 0i), kind: KindImag},
-			expectedValues: []interface{}{true, false},
+			vy:             &Visitor{value: complex128Value(2 + 0i)},
+			expectedValues: []value{boolValue(true), boolValue(false)},
 			expectedErrs:   []error{nil, nil},
 		},
 		// compare int to complex
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: int64(2), kind: KindInt},
+			vx:             &Visitor{value: int64Value(2)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: 2 + 0i, kind: KindImag},
-			expectedValues: []interface{}{true, false},
+			vy:             &Visitor{value: complex128Value(2 + 0i)},
+			expectedValues: []value{boolValue(true), boolValue(false)},
 			expectedErrs:   []error{nil, nil},
 		},
 		// compare int to float64
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: int64(2), kind: KindInt},
+			vx:             &Visitor{value: int64Value(2)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: 2.0, kind: KindFloat},
-			expectedValues: []interface{}{true, false},
+			vy:             &Visitor{value: float64Value(2.0)},
+			expectedValues: []value{boolValue(true), boolValue(false)},
 			expectedErrs:   []error{nil, nil},
 		},
 		// compare int to boolean
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: int64(10), kind: KindInt},
+			vx:             &Visitor{value: int64Value(10)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: true, kind: KindBoolean},
-			expectedValues: []interface{}{nil, nil},
+			vy:             &Visitor{value: boolValue(true)},
+			expectedValues: []value{{}, {}},
 			expectedErrs:   []error{ErrComparisonOperation, ErrComparisonOperation},
 		},
 		// compare boolean to int
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: true, kind: KindBoolean},
+			vx:             &Visitor{value: boolValue(true)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: int64(10), kind: KindInt},
-			expectedValues: []interface{}{nil, nil},
+			vy:             &Visitor{value: int64Value(10)},
+			expectedValues: []value{{}, {}},
 			expectedErrs:   []error{ErrComparisonOperation, ErrComparisonOperation},
 		},
 		// compare boolean to string
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: true, kind: KindBoolean},
+			vx:             &Visitor{value: boolValue(true)},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: "true", kind: KindString},
-			expectedValues: []interface{}{nil, nil},
+			vy:             &Visitor{value: stringValue("true")},
+			expectedValues: []value{{}, {}},
 			expectedErrs:   []error{ErrComparisonOperation, ErrComparisonOperation},
 		},
 		// compare string to boolean
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "true", kind: KindString},
+			vx:             &Visitor{value: stringValue("true")},
 			ops:            []token.Token{token.EQL, token.NEQ},
-			vy:             &Visitor{value: true, kind: KindBoolean},
-			expectedValues: []interface{}{nil, nil},
+			vy:             &Visitor{value: boolValue(true)},
+			expectedValues: []value{{}, {}},
 			expectedErrs:   []error{ErrComparisonOperation, ErrComparisonOperation},
 		},
 	}
 
-	for _, tc := range tt {
+	for i, tc := range tt {
+		if i < 3 {
+			continue
+		}
 		tc := tc
 
-		for i, op := range tc.ops {
+		for j, op := range tc.ops {
 			var (
 				op            = op
-				expectedErr   = tc.expectedErrs[i]
-				expectedValue = tc.expectedValues[i]
+				expectedErr   = tc.expectedErrs[j]
+				expectedValue = tc.expectedValues[j]
 				be            = &ast.BinaryExpr{
 					X:  &ast.BasicLit{Value: fmt.Sprintf("%v", tc.vx.value)},
 					Op: op,
 					Y:  &ast.BasicLit{Value: fmt.Sprintf("%v", tc.vy.value)},
 				}
-				name = fmt.Sprintf("%v %s %v", tc.vx.value, op, tc.vy.value)
+				name = fmt.Sprintf("%v %s %v", tc.vx.value.Any(), op, tc.vy.value.Any())
 			)
 
-			t.Run(name, func(t *testing.T) {
+			t.Run(fmt.Sprintf("[%d][%d] %s", i, j, name), func(t *testing.T) {
 				comparison(tc.v, tc.vx, tc.vy, be)
 				if !errors.Is(tc.v.err, expectedErr) {
 					t.Fatalf("expected err: %v, got: %v", expectedErr, tc.v.err)
 				}
 
-				if tc.v.value != expectedValue {
-					t.Fatalf("expected value: %v (%T), got: %v (%T)", expectedValue, expectedValue,
+				if tc.v.value.Any() != expectedValue.Any() {
+					t.Fatalf("expected value: %v (%T), got: %v (%T)", expectedValue.Any(), tc.v.value.Any(),
 						tc.v.value, tc.v.value)
 				}
 			})

--- a/docs.go
+++ b/docs.go
@@ -11,5 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package expr is the core of this library, it contains implementation to parse and evaluate mathematical and boolean expression.
+// Package expr hosts the implementation of string expression evaluator
+// to evaluate basic mathematical expression and boolean expression.
 package expr

--- a/exp/explain/explain.go
+++ b/exp/explain/explain.go
@@ -22,7 +22,7 @@ import (
 // One step can have multiple equivalent forms, starts with original form until the final form.
 type Step struct {
 	EquivalentForms []string
-	Explaination    string
+	Explanation     string
 	Result          string
 }
 
@@ -43,7 +43,7 @@ func Explain(s string) ([]Step, error) {
 	for _, transform := range v.transforms {
 		step := Step{
 			EquivalentForms: []string{transform.Segmented},
-			Explaination:    transform.Explaination,
+			Explanation:     transform.Explanation,
 			Result:          transform.Evaluated,
 		}
 		if transform.Segmented != transform.EquivalentForm {

--- a/exp/explain/visitor.go
+++ b/exp/explain/visitor.go
@@ -39,7 +39,7 @@ const (
 type Transform struct {
 	Segmented      string
 	EquivalentForm string
-	Explaination   string
+	Explanation    string
 	Evaluated      string
 }
 
@@ -212,7 +212,7 @@ func explainBitwise(transform *Transform, xValue, yValue string, op token.Token)
 	ybits := fmt.Sprintf(formatter, int64(fy))
 
 	if op != token.SHL && op != token.SHR {
-		transform.Explaination = fmt.Sprintf("%s\n%s\n%s %s\n%s",
+		transform.Explanation = fmt.Sprintf("%s\n%s\n%s %s\n%s",
 			xbits, ybits,
 			strings.Repeat("-", (size*2)-(size*2/10)), operatorStringMap[op],
 			fmt.Sprintf(formatter, result))
@@ -229,6 +229,6 @@ func explainBitwise(transform *Transform, xValue, yValue string, op token.Token)
 		result = int64(fx) >> int64(fy)
 	}
 
-	transform.Explaination = fmt.Sprintf("%s %s-shifted by %d = %s",
+	transform.Explanation = fmt.Sprintf("%s %s-shifted by %d = %s",
 		xbits, shiftDirection, int64(fy), fmt.Sprintf(formatter, result))
 }

--- a/exp/explain/visitor_test.go
+++ b/exp/explain/visitor_test.go
@@ -158,9 +158,9 @@ func TestVisit(t *testing.T) {
 
 			transforms := v.Value()
 
-			// Ignore Explaination
+			// Ignore Explanation
 			for i := range transforms {
-				transforms[i].Explaination = ""
+				transforms[i].Explanation = ""
 			}
 
 			if diff := cmp.Diff(transforms, tc.transforms); diff != "" {

--- a/expr.go
+++ b/expr.go
@@ -14,7 +14,6 @@
 package expr
 
 import (
-	"go/ast"
 	"go/parser"
 )
 
@@ -39,24 +38,33 @@ func Any(str string) (interface{}, error) {
 		return nil, err
 	}
 
-	v := NewVisitor(
-		WithAllowIntegerDividedByZero(true),
-		WithNumericType(NumericTypeAuto),
-	)
-	ast.Walk(v, expr)
+	var v Visitor
+	v.options = defaultOptions()
+	v.options.allowIntegerDividedByZero = true
+	v.options.numericType = NumericTypeAuto
 
+	v.Visit(expr)
 	if err := v.Err(); err != nil {
 		return nil, err
 	}
 
-	switch val := v.value.(type) {
-	case float64:
+	switch v.value.Kind() {
+	case KindBoolean:
+		return v.value.Bool(), nil
+	case KindInt:
+		return v.value.Int64(), nil
+	case KindFloat:
+		val := v.value.Float64()
 		if val == float64(int64(val)) {
 			return int64(val), nil
 		}
 		return val, nil
+	case KindImag:
+		return v.value.Complex128(), nil
+	case KindString:
+		return v.value.String(), nil
 	default:
-		return val, nil
+		return nil, nil
 	}
 }
 
@@ -81,15 +89,16 @@ func Bool(str string) (bool, error) {
 		return false, err
 	}
 
-	v := NewVisitor()
-	ast.Walk(v, expr)
+	var v Visitor
+	v.options = defaultOptions()
 
+	v.Visit(expr)
 	if err := v.Err(); err != nil {
 		return false, err
 	}
 
-	if val, ok := v.value.(bool); ok {
-		return val, nil
+	if v.value.Kind() == KindBoolean {
+		return v.value.Bool(), nil
 	}
 
 	return false, ErrValueTypeMismatch
@@ -108,20 +117,22 @@ func Complex128(str string) (complex128, error) {
 		return 0, err
 	}
 
-	v := NewVisitor(WithNumericType(NumericTypeComplex))
-	ast.Walk(v, expr)
+	var v Visitor
+	v.options = defaultOptions()
+	v.options.numericType = NumericTypeComplex
 
+	v.Visit(expr)
 	if err := v.Err(); err != nil {
 		return 0, err
 	}
 
-	switch val := v.value.(type) {
-	case complex128:
-		return val, nil
-	case float64:
-		return complex(val, 0), nil
-	case int64:
-		return complex(float64(val), 0), nil
+	switch v.value.Kind() {
+	case KindImag:
+		return v.value.Complex128(), nil
+	case KindFloat:
+		return complex(v.value.Float64(), 0), nil
+	case KindInt:
+		return complex(float64(v.value.Int64()), 0), nil
 	}
 
 	return 0, ErrValueTypeMismatch
@@ -141,20 +152,22 @@ func Float64(str string) (float64, error) {
 		return 0, err
 	}
 
-	v := NewVisitor(WithNumericType(NumericTypeFloat))
-	ast.Walk(v, expr)
+	var v Visitor
+	v.options = defaultOptions()
+	v.options.numericType = NumericTypeFloat
 
+	v.Visit(expr)
 	if err := v.Err(); err != nil {
 		return 0, err
 	}
 
-	switch val := v.value.(type) {
-	case complex128:
-		return real(val), nil
-	case float64:
-		return val, nil
-	case int64:
-		return float64(val), nil
+	switch v.value.Kind() {
+	case KindImag:
+		return real(v.value.Complex128()), nil
+	case KindFloat:
+		return v.value.Float64(), nil
+	case KindInt:
+		return float64(v.value.Int64()), nil
 	}
 
 	return 0, ErrValueTypeMismatch
@@ -192,23 +205,23 @@ func parseStringExprIntoInt64(str string, allowIntegerDividedByZero bool) (int64
 		return 0, err
 	}
 
-	v := NewVisitor(
-		WithNumericType(NumericTypeInt),
-		WithAllowIntegerDividedByZero(allowIntegerDividedByZero),
-	)
-	ast.Walk(v, expr)
+	var v Visitor
+	v.options = defaultOptions()
+	v.options.allowIntegerDividedByZero = allowIntegerDividedByZero
+	v.options.numericType = NumericTypeInt
 
+	v.Visit(expr)
 	if err := v.Err(); err != nil {
 		return 0, err
 	}
 
-	switch val := v.value.(type) {
-	case complex128:
-		return int64(real(val)), nil
-	case float64:
-		return int64(val), nil
-	case int64:
-		return val, nil
+	switch v.value.Kind() {
+	case KindImag:
+		return int64(real(v.value.Complex128())), nil
+	case KindFloat:
+		return int64(v.value.Float64()), nil
+	case KindInt:
+		return v.value.Int64(), nil
 	}
 
 	return 0, ErrValueTypeMismatch

--- a/expr.go
+++ b/expr.go
@@ -61,10 +61,8 @@ func Any(str string) (interface{}, error) {
 		return val, nil
 	case KindImag:
 		return v.value.Complex128(), nil
-	case KindString:
-		return v.value.String(), nil
 	default:
-		return nil, nil
+		return v.value.String(), nil
 	}
 }
 

--- a/expr_test.go
+++ b/expr_test.go
@@ -77,7 +77,7 @@ func TestAny(t *testing.T) {
 			}
 
 			if v != tc.Eq {
-				t.Fatalf("expected value: %f, got: %f", tc.Eq, v)
+				t.Fatalf("expected value: %T(%v), got: %T(%v)", tc.Eq, tc.Eq, v, v)
 			}
 		})
 	}

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/logical.go
+++ b/logical.go
@@ -22,31 +22,30 @@ import (
 )
 
 func logical(v, vx, vy *Visitor, binaryExpr *ast.BinaryExpr) {
-	if vx.kind != KindBoolean {
+	if vx.value.Kind() != KindBoolean {
 		v.err = newLogicalNonBooleanError(vx, binaryExpr.X)
 		return
 	}
-	if vy.kind != KindBoolean {
+	if vy.value.Kind() != KindBoolean {
 		v.err = newLogicalNonBooleanError(vy, binaryExpr.Y)
 		return
 	}
 
-	x := vx.value.(bool)
-	y := vy.value.(bool)
+	x := vx.value.Bool()
+	y := vy.value.Bool()
 
-	v.kind = KindBoolean
+	v.value.SetKind(KindBoolean)
 	if binaryExpr.Op == token.LAND {
-		v.value = x && y
+		v.value = boolValue(x && y)
 		return
 	}
-
-	v.value = x || y // token.LOR
+	v.value = boolValue(x || y) // token.LOR
 }
 
 func newLogicalNonBooleanError(v *Visitor, e ast.Expr) error {
 	s := conv.FormatExpr(e)
 	return &SyntaxError{
-		Msg: "result of \"" + s + "\" is \"" + fmt.Sprintf("%v", v.value) + "\" which is not a boolean",
+		Msg: "result of \"" + s + "\" is \"" + fmt.Sprintf("%v", v.value.Any()) + "\" which is not a boolean",
 		Pos: v.pos,
 		Err: ErrLogicalOperation,
 	}

--- a/logical_test.go
+++ b/logical_test.go
@@ -25,31 +25,31 @@ func TestLogical(t *testing.T) {
 	tt := []struct {
 		v, vx, vy      *Visitor
 		ops            []token.Token
-		expectedValues []interface{}
+		expectedValues []value
 		expectedErrs   []error
 	}{
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: true, kind: KindBoolean},
+			vx:             &Visitor{value: boolValue(true)},
 			ops:            []token.Token{token.LAND, token.NEQ},
-			vy:             &Visitor{value: false, kind: KindBoolean},
-			expectedValues: []interface{}{false, true},
+			vy:             &Visitor{value: boolValue(false)},
+			expectedValues: []value{boolValue(false), boolValue(true)},
 			expectedErrs:   []error{nil, nil},
 		},
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "1", kind: KindInt},
+			vx:             &Visitor{value: stringValue("1")},
 			ops:            []token.Token{token.LAND},
-			vy:             &Visitor{value: "false", kind: KindBoolean},
-			expectedValues: []interface{}{nil},
+			vy:             &Visitor{value: stringValue("false")},
+			expectedValues: []value{{}},
 			expectedErrs:   []error{ErrLogicalOperation},
 		},
 		{
 			v:              &Visitor{},
-			vx:             &Visitor{value: "false", kind: KindBoolean},
+			vx:             &Visitor{value: stringValue("false")},
 			ops:            []token.Token{token.LAND},
-			vy:             &Visitor{value: "1", kind: KindInt},
-			expectedValues: []interface{}{nil},
+			vy:             &Visitor{value: stringValue("1")},
+			expectedValues: []value{{}},
 			expectedErrs:   []error{ErrLogicalOperation},
 		},
 	}
@@ -66,7 +66,7 @@ func TestLogical(t *testing.T) {
 					Op: op,
 					Y:  &ast.BasicLit{Value: fmt.Sprintf("%v", tc.vy.value)},
 				}
-				name = fmt.Sprintf("%v %s %v", tc.vx.value, op, tc.vy.value)
+				name = fmt.Sprintf("%v %s %v", tc.vx.value.Any(), op, tc.vy.value.Any())
 			)
 
 			t.Run(name, func(t *testing.T) {
@@ -74,8 +74,8 @@ func TestLogical(t *testing.T) {
 				if !errors.Is(tc.v.err, expectedErr) {
 					t.Fatalf("expected err: %v, got: %v", expectedErr, tc.v.err)
 				}
-				if tc.v.value != expectedValue {
-					t.Fatalf("expected value: %v, got: %v", expectedValue, tc.v.value)
+				if tc.v.value.Any() != expectedValue.Any() {
+					t.Fatalf("expected value: %v, got: %v", expectedValue.Any(), tc.v.value.Any())
 				}
 			})
 		}

--- a/logical_test.go
+++ b/logical_test.go
@@ -38,6 +38,14 @@ func TestLogical(t *testing.T) {
 		},
 		{
 			v:              &Visitor{},
+			vx:             &Visitor{value: boolValue(true)},
+			ops:            []token.Token{token.LAND, token.NEQ},
+			vy:             &Visitor{value: stringValue("1")},
+			expectedValues: []value{{}, {}},
+			expectedErrs:   []error{ErrLogicalOperation, ErrLogicalOperation},
+		},
+		{
+			v:              &Visitor{},
 			vx:             &Visitor{value: stringValue("1")},
 			ops:            []token.Token{token.LAND},
 			vy:             &Visitor{value: stringValue("false")},

--- a/value.go
+++ b/value.go
@@ -1,0 +1,124 @@
+package expr
+
+import (
+	"math"
+	"strconv"
+)
+
+// Kind of value (value's type)
+type Kind byte
+
+const (
+	KindIllegal Kind = iota
+	KindBoolean      // true false
+
+	// Identifiers of numeric type
+	numeric_beg
+	KindInt   // 12345
+	KindFloat // 123.45
+	KindImag  // 123.45i
+	numeric_end
+
+	KindString // "abc" 'abc' `abc`
+)
+
+var kinds = [...]string{
+	KindIllegal: "KindIllegal",
+	KindBoolean: "KindBoolean",
+	KindInt:     "KindInt",
+	KindFloat:   "KindFloat",
+	KindImag:    "KindImag",
+	KindString:  "KindString",
+}
+
+func (k Kind) String() string {
+	if k < Kind(len(kinds)) {
+		return kinds[k]
+	}
+	return "kind(" + strconv.Itoa(int(k)) + ")"
+}
+
+// value is a custom value to reduce memory allocation,
+// so we don't allocate if the value is bool, int64 or float64.
+type value struct {
+	_   [0]func()   // disallow ==
+	num uint64      // storage for bool, int64 or float64 value.
+	any interface{} // storage for Kind (only if bool, int64 or float64), complex128 value or string value.
+}
+
+// Kind returns value's kind.
+func (v *value) Kind() Kind {
+	switch k := v.any.(type) {
+	case Kind:
+		return k
+	case complex128:
+		return KindImag
+	case string:
+		return KindString
+	}
+	return KindIllegal
+}
+
+// SetKind sets value's kind.
+func (v *value) SetKind(k Kind) { v.any = k }
+
+// Bool returns value as bool.
+func (v *value) Bool() bool { return v.num == 1 }
+
+// Int64 returns value as int64.
+func (v *value) Int64() int64 { return int64(v.num) }
+
+// Float64 returns value as float64.
+func (v *value) Float64() float64 { return math.Float64frombits(v.num) }
+
+// Complex128 returns value as complex128.
+func (v *value) Complex128() complex128 {
+	val, _ := v.any.(complex128)
+	return val
+}
+
+// String returns value as string.
+func (v *value) String() string {
+	s, _ := v.any.(string)
+	return s
+}
+
+// Any returns underlying value as interface{}.
+func (v *value) Any() interface{} {
+	switch v.Kind() {
+	case KindBoolean:
+		return v.num == 1
+	case KindInt:
+		return int64(v.num)
+	case KindFloat:
+		return math.Float64frombits(v.num)
+	case KindImag:
+		v, _ := v.any.(complex128)
+		return v
+	case KindString:
+		s, _ := v.any.(string)
+		return s
+	}
+	return nil
+}
+
+// boolValue creates boolean value.
+func boolValue(v bool) value {
+	var num uint64
+	if v {
+		num = 1
+	}
+	return value{num: num, any: KindBoolean}
+}
+
+// int64Value creates int64 value.
+func int64Value(v int64) value { return value{num: uint64(v), any: KindInt} }
+
+// float64Value creates float64 value.
+func float64Value(v float64) value { return value{num: math.Float64bits(v), any: KindFloat} }
+
+// complex128Value creates complex128 value.
+func complex128Value(v complex128) value { return value{any: v} }
+
+// stringValue creates string value.
+func stringValue(v string) value { return value{any: v} }

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -19,7 +19,44 @@ import (
 	"go/ast"
 	"go/parser"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+func TestOptions(t *testing.T) {
+	tt := []struct {
+		name    string
+		opts    []Option
+		options options
+	}{
+		{
+			name:    "defaultOptions",
+			options: defaultOptions(),
+		},
+		{
+			name: "with options",
+			opts: []Option{
+				WithAllowIntegerDividedByZero(true),
+				WithNumericType(NumericTypeInt),
+			},
+			options: options{
+				allowIntegerDividedByZero: true,
+				numericType:               NumericTypeInt,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewVisitor(tc.opts...)
+			if diff := cmp.Diff(v.options, tc.options,
+				cmp.AllowUnexported(options{}),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
 
 func TestVisit(t *testing.T) {
 	tt := []struct {
@@ -96,9 +133,6 @@ func TestVisit(t *testing.T) {
 	}
 
 	for i, tc := range tt {
-		if i < 2 {
-			continue
-		}
 		tc := tc
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.in), func(t *testing.T) {
 			e, err := parser.ParseExpr(tc.in)

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -11,107 +11,109 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package expr_test
+package expr
 
 import (
 	"errors"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"testing"
-
-	"github.com/muktihari/expr"
 )
 
 func TestVisit(t *testing.T) {
 	tt := []struct {
 		in            string
-		expectedValue interface{}
-		expectedKind  expr.Kind
+		expectedValue value
+		expectedKind  Kind
 		expectedErr   error
 	}{
 		{
 			in:           "<-a", // unary operator
-			expectedKind: expr.KindIllegal,
-			expectedErr:  expr.ErrUnsupportedOperator,
+			expectedKind: KindIllegal,
+			expectedErr:  ErrUnsupportedOperator,
 		},
 		{
 			in:            "'a' == 'a'",
-			expectedValue: true,
-			expectedKind:  expr.KindBoolean,
+			expectedValue: boolValue(true),
+			expectedKind:  KindBoolean,
 		},
 		{
 			in:            "-(20+10i)",
-			expectedValue: -(20 + 10i),
-			expectedKind:  expr.KindImag,
+			expectedValue: complex128Value(-(20 + 10i)),
+			expectedKind:  KindImag,
 		},
 		{
 			in:            "true && 20 > 9",
-			expectedValue: true,
-			expectedKind:  expr.KindBoolean,
+			expectedValue: boolValue(true),
+			expectedKind:  KindBoolean,
 		},
 		{
 			in:            "1 + 1",
-			expectedValue: float64(2),
-			expectedKind:  expr.KindFloat,
+			expectedValue: float64Value(2),
+			expectedKind:  KindFloat,
 		},
 		{
 			in:            "1 + 2 * 10",
-			expectedValue: float64(21),
-			expectedKind:  expr.KindFloat,
+			expectedValue: float64Value(21),
+			expectedKind:  KindFloat,
 		},
 		{
 			in:            "2.5 * 2.1",
-			expectedValue: float64(5.25),
-			expectedKind:  expr.KindFloat,
+			expectedValue: float64Value(5.25),
+			expectedKind:  KindFloat,
 		},
 		{
 			in:            "2.50 > 2.4",
-			expectedValue: true,
-			expectedKind:  expr.KindBoolean,
+			expectedValue: boolValue(true),
+			expectedKind:  KindBoolean,
 		},
 		{
 			in:           "true & 2.4",
-			expectedKind: expr.KindIllegal,
-			expectedErr:  expr.ErrBitwiseOperation,
+			expectedKind: KindIllegal,
+			expectedErr:  ErrBitwiseOperation,
 		},
 		{
 			in:            "4 == 0b0100",
-			expectedValue: true,
-			expectedKind:  expr.KindBoolean,
+			expectedValue: boolValue(true),
+			expectedKind:  KindBoolean,
 		},
 		{
 			in:           "true || !(!(10 * 100 %2))",
-			expectedKind: expr.KindIllegal,
-			expectedErr:  expr.ErrUnaryOperation,
+			expectedKind: KindIllegal,
+			expectedErr:  ErrUnaryOperation,
 		},
 		{
 			in:           "!(!(10 * 100 %2)) || true ",
-			expectedKind: expr.KindIllegal,
-			expectedErr:  expr.ErrUnaryOperation,
+			expectedKind: KindIllegal,
+			expectedErr:  ErrUnaryOperation,
 		},
 		{
 			in:            "expr == expr",
-			expectedValue: true,
-			expectedKind:  expr.KindBoolean,
+			expectedValue: boolValue(true),
+			expectedKind:  KindBoolean,
 		},
 	}
 
-	for _, tc := range tt {
+	for i, tc := range tt {
+		if i < 2 {
+			continue
+		}
 		tc := tc
-		t.Run(tc.in, func(t *testing.T) {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.in), func(t *testing.T) {
 			e, err := parser.ParseExpr(tc.in)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			v := expr.NewVisitor(expr.WithNumericType(expr.NumericTypeAuto))
+			v := NewVisitor(WithNumericType(NumericTypeAuto))
 			ast.Walk(v, e)
 
 			if err := v.Err(); !errors.Is(err, tc.expectedErr) {
 				t.Fatalf("expected err: %v, got: %v", tc.expectedErr, err)
 			}
-			if val := v.ValueAny(); val != tc.expectedValue {
-				t.Fatalf("expected val: %v (%T), got: %v (%T)", tc.expectedValue, tc.expectedValue, val, val)
+			if val := v.ValueAny(); val != tc.expectedValue.Any() {
+				t.Fatalf("expected val: %v (%T), got: %v (%T)", tc.expectedValue.Any(), tc.expectedValue.Any(), val, val)
 			}
 			if kind := v.Kind(); kind != tc.expectedKind {
 				t.Fatalf("expected kind: %v, got: %v", tc.expectedKind, kind)
@@ -121,22 +123,22 @@ func TestVisit(t *testing.T) {
 
 	tt2 := []struct {
 		in       ast.Expr
-		expected *expr.Visitor
+		expected *Visitor
 	}{
 		{
 			in:       nil,
-			expected: &expr.Visitor{},
+			expected: &Visitor{},
 		},
 		{
 			in:       &ast.BadExpr{},
-			expected: &expr.Visitor{},
+			expected: &Visitor{},
 		},
 	}
 
 	for _, tc := range tt2 {
 		tc := tc
 		t.Run("", func(t *testing.T) {
-			v := &expr.Visitor{}
+			v := &Visitor{}
 			ast.Walk(v, tc.in)
 			if v.Err() != tc.expected.Err() {
 				t.Fatalf("expected err: %v, got: %v", tc.expected.Err(), v.Err())
@@ -153,18 +155,18 @@ func TestVisit(t *testing.T) {
 
 func TestKindString(t *testing.T) {
 	kinds := [...]string{
-		expr.KindIllegal: "KindIllegal",
-		expr.KindBoolean: "KindBoolean",
-		expr.KindInt:     "KindInt",
-		expr.KindFloat:   "KindFloat",
-		expr.KindImag:    "KindImag",
-		expr.KindString:  "KindString",
+		KindIllegal: "KindIllegal",
+		KindBoolean: "KindBoolean",
+		KindInt:     "KindInt",
+		KindFloat:   "KindFloat",
+		KindImag:    "KindImag",
+		KindString:  "KindString",
 	}
 
 	for kind, expected := range kinds {
 		kind, expected := kind, expected
 		t.Run(expected, func(t *testing.T) {
-			kind := expr.Kind(kind)
+			kind := Kind(kind)
 			if kind.String() != expected {
 				t.Fatalf("expected kind string: %s, got: %s", expected, kind.String())
 			}
@@ -173,7 +175,7 @@ func TestKindString(t *testing.T) {
 
 	// unsupported kinds
 	tt := []struct {
-		kind     expr.Kind
+		kind     Kind
 		expected string
 	}{
 		{kind: 255, expected: "kind(255)"},


### PR DESCRIPTION
- When we encounter value: `bool`, `int64`, or `float64`; those value is no longer allocate.
- Reduce `bind` memory alloc by not concating prefix and suffix on value lookup.

#### Expr Benchmark
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/expr
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                      │   old.txt    │               new.txt               │
                      │    sec/op    │   sec/op     vs base                │
Any/KindBoolean-4       10.74µ ±  4%   10.20µ ± 1%   -5.05% (p=0.000 n=10)
Any/KindInt-4           4.997µ ±  0%   4.712µ ± 0%   -5.69% (p=0.000 n=10)
Any/KindFloat-4         7.275µ ±  0%   6.886µ ± 0%   -5.35% (p=0.000 n=10)
Any/KindImag-4          5.430µ ± 12%   5.017µ ± 0%   -7.62% (p=0.000 n=10)
Boolean/KindBoolean-4   13.12µ ± 25%   10.19µ ± 1%  -22.30% (p=0.000 n=10)
Complex128/KindImag-4   5.052µ ± 18%   4.966µ ± 1%   -1.70% (p=0.002 n=10)
Float64/KindFloat-4     7.331µ ±  3%   6.772µ ± 0%   -7.63% (p=0.000 n=10)
Int64/KindInt-4         8.484µ ± 44%   4.677µ ± 0%  -44.87% (p=0.000 n=10)
geomean                 7.373µ         6.355µ       -13.81%

                      │   old.txt    │               new.txt               │
                      │     B/op     │     B/op      vs base               │
Any/KindBoolean-4       2.703Ki ± 0%   2.578Ki ± 0%  -4.62% (p=0.000 n=10)
Any/KindInt-4           1.531Ki ± 0%   1.391Ki ± 0%  -9.18% (p=0.000 n=10)
Any/KindFloat-4         2.016Ki ± 0%   1.836Ki ± 0%  -8.91% (p=0.000 n=10)
Any/KindImag-4          1.602Ki ± 0%   1.531Ki ± 0%  -4.39% (p=0.000 n=10)
Boolean/KindBoolean-4   2.672Ki ± 0%   2.578Ki ± 0%  -3.51% (p=0.000 n=10)
Complex128/KindImag-4   1.586Ki ± 0%   1.516Ki ± 0%  -4.43% (p=0.000 n=10)
Float64/KindFloat-4     1.992Ki ± 0%   1.828Ki ± 0%  -8.24% (p=0.000 n=10)
Int64/KindInt-4         1.469Ki ± 0%   1.391Ki ± 0%  -5.32% (p=0.000 n=10)
geomean                 1.894Ki        1.779Ki       -6.10%

                      │  old.txt   │              new.txt               │
                      │ allocs/op  │ allocs/op   vs base                │
Any/KindBoolean-4       72.00 ± 0%   62.00 ± 0%  -13.89% (p=0.000 n=10)
Any/KindInt-4           44.00 ± 0%   32.00 ± 0%  -27.27% (p=0.000 n=10)
Any/KindFloat-4         61.00 ± 0%   44.00 ± 0%  -27.87% (p=0.000 n=10)
Any/KindImag-4          48.00 ± 0%   45.00 ± 0%   -6.25% (p=0.000 n=10)
Boolean/KindBoolean-4   70.00 ± 0%   62.00 ± 0%  -11.43% (p=0.000 n=10)
Complex128/KindImag-4   47.00 ± 0%   44.00 ± 0%   -6.38% (p=0.000 n=10)
Float64/KindFloat-4     59.00 ± 0%   43.00 ± 0%  -27.12% (p=0.000 n=10)
Int64/KindInt-4         36.00 ± 0%   32.00 ± 0%  -11.11% (p=0.000 n=10)
geomean                 53.27        44.27       -16.90%

```

#### Bind Benchmark
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/expr/bind
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                                                                    │    old.txt    │               new.txt                │
                                                                    │    sec/op     │    sec/op     vs base                │
Bind/extra_small_len(s):76,_len(varInStrCount):_4,_vars:4/Bind-4       1.790µ ± 47%   1.524µ ± 20%  -14.83% (p=0.003 n=10)
Bind/small_len(s):643,_len(varInStrCount):_43,_vars:12/Bind-4          11.04µ ±  9%   10.72µ ± 31%        ~ (p=0.684 n=10)
Bind/medium_len(s):6133,_len(varInStrCount):_403,_vars:102/Bind-4      100.2µ ±  2%   104.2µ ± 29%        ~ (p=0.280 n=10)
Bind/large_len(s):61933,_len(varInStrCount):_4003,_vars:1002/Bind-4   1052.6µ ± 42%   990.8µ ±  6%   -5.88% (p=0.035 n=10)
geomean                                                                38.00µ         36.04µ         -5.16%

                                                                    │   old.txt    │               new.txt                │
                                                                    │     B/op     │     B/op      vs base                │
Bind/extra_small_len(s):76,_len(varInStrCount):_4,_vars:4/Bind-4        240.0 ± 0%     184.0 ± 0%  -23.33% (p=0.000 n=10)
Bind/small_len(s):643,_len(varInStrCount):_43,_vars:12/Bind-4         2.134Ki ± 0%   1.939Ki ± 0%   -9.11% (p=0.000 n=10)
Bind/medium_len(s):6133,_len(varInStrCount):_403,_vars:102/Bind-4     18.34Ki ± 0%   16.74Ki ± 0%   -8.75% (p=0.000 n=10)
Bind/large_len(s):61933,_len(varInStrCount):_4003,_vars:1002/Bind-4   277.7Ki ± 0%   262.0Ki ± 0%   -5.64% (p=0.000 n=10)
geomean                                                               7.104Ki        6.253Ki       -11.99%

                                                                    │   old.txt   │               new.txt               │
                                                                    │  allocs/op  │  allocs/op   vs base                │
Bind/extra_small_len(s):76,_len(varInStrCount):_4,_vars:4/Bind-4      13.000 ± 0%    9.000 ± 0%  -30.77% (p=0.000 n=10)
Bind/small_len(s):643,_len(varInStrCount):_43,_vars:12/Bind-4          43.00 ± 0%    31.00 ± 0%  -27.91% (p=0.000 n=10)
Bind/medium_len(s):6133,_len(varInStrCount):_403,_vars:102/Bind-4      320.0 ± 0%    218.0 ± 0%  -31.87% (p=0.000 n=10)
Bind/large_len(s):61933,_len(varInStrCount):_4003,_vars:1002/Bind-4   3.027k ± 0%   2.025k ± 0%  -33.10% (p=0.000 n=10)
geomean                                                                152.5         105.3       -30.94%

```